### PR TITLE
Feature/cax 1 prs@175 Postgres passwd

### DIFF
--- a/coreservices/partsrelationshipservice/terraform/modules/postgresql/main.tf
+++ b/coreservices/partsrelationshipservice/terraform/modules/postgresql/main.tf
@@ -1,6 +1,8 @@
 resource "random_password" "postgresql_admin" {
   length  = 16
   special = true
+  override_special = "!@#$%*()-_=+[]{}:?" # use only characters that Terraform doesn't escape in JSON output (user-friendly)
+
 }
 
 resource "azurerm_postgresql_server" "main" {

--- a/coreservices/partsrelationshipservice/terraform/modules/postgresql/main.tf
+++ b/coreservices/partsrelationshipservice/terraform/modules/postgresql/main.tf
@@ -1,8 +1,7 @@
 resource "random_password" "postgresql_admin" {
-  length  = 16
-  special = true
+  length           = 16
+  special          = true
   override_special = "!@#$%*()-_=+[]{}:?" # use only characters that Terraform doesn't escape in JSON output (user-friendly)
-
 }
 
 resource "azurerm_postgresql_server" "main" {


### PR DESCRIPTION
Reduce range of special characters used in PostgreSQL password, so that the output of `terraform output -json` can easily be copied into a database visualiser.