### PR TITLE
Feature/cax 1 prs@173 Ingress -  use public IP instead of app routing.

### DIFF
--- a/.github/workflows/partsrelationshipservice-deploy.yml
+++ b/.github/workflows/partsrelationshipservice-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feature/CAX-1-PRS@173-ingress
     paths:
       - coreservices/partsrelationshipservice/**
       - .github/workflows/partsrelationshipservice-deploy.yml

--- a/.github/workflows/partsrelationshipservice-deploy.yml
+++ b/.github/workflows/partsrelationshipservice-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/CAX-1-PRS@173-ingress
     paths:
       - coreservices/partsrelationshipservice/**
       - .github/workflows/partsrelationshipservice-deploy.yml

--- a/.github/workflows/partsrelationshipservice-deploy.yml
+++ b/.github/workflows/partsrelationshipservice-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       TF_VAR_image_registry: catenaxdev001acr.azurecr.io
       # Ingress host to reach the PRS service.
-      TF_VAR_ingress_host: prsdev.d5a2b853cc864506ac03.germanywestcentral.aksapp.io
+      TF_VAR_ingress_host: catenaxdev001akssrv.germanywestcentral.cloudapp.azure.com
       TF_VAR_aks_cluster_name: catenax-dev001-aks-services
       TF_VAR_resource_group_name: catenax-dev001-rg
       TF_VAR_release_name: prs

--- a/coreservices/partsrelationshipservice/helm/prs/templates/ingress.yaml
+++ b/coreservices/partsrelationshipservice/helm/prs/templates/ingress.yaml
@@ -2,8 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: prs-ingress
-  annotations:
-    kubernetes.io/ingress.class: addon-http-application-routing
+
 spec:
   rules:
     - host: {{ .Values.ingress.host }}

--- a/coreservices/partsrelationshipservice/helm/prs/values.yaml
+++ b/coreservices/partsrelationshipservice/helm/prs/values.yaml
@@ -2,7 +2,6 @@ replicaCount: 1
 
 ingress:
   host: prs.local
-  prefix: /prs
 
 prs:
   image:

--- a/coreservices/partsrelationshipservice/terraform/variables.tf
+++ b/coreservices/partsrelationshipservice/terraform/variables.tf
@@ -41,7 +41,7 @@ variable "release_name" {
 variable "ingress_host" {
   type        = string
   description = "Ingress host to reach the application."
-  default     = "prsdev.d5a2b853cc864506ac03.germanywestcentral.aksapp.io"
+  default     = "catenaxdev001akssrv.germanywestcentral.cloudapp.azure.com"
 }
 
 variable "image_tag" {


### PR DESCRIPTION
- Application routing is now disabled in the AKS cluter.
- Used the public IP dns name.