### PR TITLE
Fix/cax 1 prs@180 Removed curly brackets from possible special chars in postgres password.

### DIFF
--- a/.github/workflows/partsrelationshipservice-deploy.yml
+++ b/.github/workflows/partsrelationshipservice-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Deploy PRS
 
 on:
   push:

--- a/.github/workflows/partsrelationshipservice-deploy.yml
+++ b/.github/workflows/partsrelationshipservice-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy PRS
+name: Deploy
 
 on:
   push:

--- a/coreservices/partsrelationshipservice/terraform/modules/postgresql/main.tf
+++ b/coreservices/partsrelationshipservice/terraform/modules/postgresql/main.tf
@@ -1,7 +1,7 @@
 resource "random_password" "postgresql_admin" {
   length           = 16
   special          = true
-  override_special = "!@#$%*()-_=+[]{}:?" # use only characters that Terraform doesn't escape in JSON output (user-friendly)
+  override_special = "!@#$%*()-_=+[]:?" # use only characters that Terraform doesn't escape in JSON output (user-friendly)
 }
 
 resource "azurerm_postgresql_server" "main" {


### PR DESCRIPTION
If the generated password starts by '{' we end up with a parsing error because it expect it to end by }
To avoid this issue we remove it from the possible chars.