### PR TITLE
feature/CAX-1-PRS@178-storedproc-tests

### DIFF
--- a/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/entities/PartIdEntityPart.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/entities/PartIdEntityPart.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
 @Embeddable
 @Getter
 @Setter
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString // safe on this entity as it has no relationships

--- a/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/repositories/PartRelationshipRepository.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/repositories/PartRelationshipRepository.java
@@ -22,17 +22,25 @@ import java.util.List;
  */
 public interface PartRelationshipRepository extends JpaRepository<PartRelationshipEntity, PartRelationshipEntityKey> {
     /**
-     * Call stored procedure to recursively retrieve the parts tree from a given part.
+     * Call database function (analog to a stored procedure)
+     * to recursively retrieve the parts tree from a given part.
+     * <p>
+     * Note that this method does not validate its parameters, and validation
+     * must be performed by the caller.
      *
      * @param oneIDManufacturer    see {@link PartIdEntityPart#getOneIDManufacturer()}.
+     *                             Must not be {@literal null} or blank.
      * @param objectIDManufacturer see {@link PartIdEntityPart#getObjectIDManufacturer()}.
+     *                             Must not be {@literal null} or blank.
      * @param maxDepth             maximum depth to traverse the tree.
-     * @return edges in the parts tree below the given part.
+     *                             Must be strictly positive.
+     * @return edges in the parts tree below the given part, or an empty list if no edges
+     * are found. Guaranteed to never return {@literal null}.
      */
     @Query(nativeQuery = true, value = "SELECT * FROM get_parts_tree(:oneIDManufacturer, :objectIDManufacturer, :maxDepth)")
     List<PartRelationshipEntity> getPartsTree(
-        String oneIDManufacturer,
-        String objectIDManufacturer,
-        int maxDepth);
+            String oneIDManufacturer,
+            String objectIDManufacturer,
+            int maxDepth);
 }
 

--- a/coreservices/partsrelationshipservice/prs-api/src/main/resources/db/migration/V1_2__recursive_query.sql
+++ b/coreservices/partsrelationshipservice/prs-api/src/main/resources/db/migration/V1_2__recursive_query.sql
@@ -13,7 +13,7 @@ WITH RECURSIVE r(
     depth,
     path
 ) AS (
-    -- ROOT node query
+    -- root node query
     SELECT edge,
         parent_oneidmanufacturer,
         parent_objectidmanufacturer,
@@ -38,13 +38,11 @@ WITH RECURSIVE r(
     WHERE e.parent_oneidmanufacturer = r.oneidmanufacturer
         and e.parent_objectidmanufacturer = r.objectidmanufacturer
         AND (
-            (
                 e.parent_oneidmanufacturer,
                 e.parent_objectidmanufacturer
             ) <> ALL(r.path) -- avoid cycles
-        )
-        and depth<max_depth
+        and depth < max_depth
 )
-SELECT (r.edge).*
+SELECT DISTINCT (r.edge).*
 FROM r
 $$;

--- a/coreservices/partsrelationshipservice/prs-api/src/test/java/net/catenax/prs/repositories/PartRelationshipRepositoryTests.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/test/java/net/catenax/prs/repositories/PartRelationshipRepositoryTests.java
@@ -4,7 +4,11 @@ import com.github.javafaker.Faker;
 import net.catenax.prs.entities.PartIdEntityPart;
 import net.catenax.prs.entities.PartRelationshipEntity;
 import net.catenax.prs.entities.PartsMother;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -15,6 +19,7 @@ import java.util.List;
 
 import static net.catenax.prs.testing.TestUtil.DATABASE_TESTCONTAINER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
 
 @DataJpaTest
@@ -25,40 +30,229 @@ import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTest
 })
 public class PartRelationshipRepositoryTests {
     @Autowired
-    private PartRelationshipRepository repository;
+    PartRelationshipRepository repository;
 
     @Autowired
-    private TestEntityManager entityManager;
+    TestEntityManager entityManager;
 
-    private PartsMother generate = new PartsMother();
+    PartsMother generate = new PartsMother();
 
-    private final Faker faker = new Faker();
+    Faker faker = new Faker();
 
-    PartIdEntityPart car1 = generate.partId();
-    PartIdEntityPart gearbox1 = generate.partId();
-    PartIdEntityPart gearwheel1 = generate.partId();
-    PartRelationshipEntity car1_gearbox1 = generate.partRelationship(car1, gearbox1);
-    PartRelationshipEntity gearbox1_gearwheel1 = generate.partRelationship(gearbox1, gearwheel1);
+    /**
+     * Parts with {@literal A} in their names form the BOM of {@link #carA}.
+     */
+    PartIdEntityPart carA = generate.partId();
+    PartIdEntityPart gearboxA = generate.partId();
+    PartIdEntityPart gearwheelA1 = generate.partId();
+    PartIdEntityPart gearwheelA2 = generate.partId();
+    PartIdEntityPart screwA1 = generate.partId();
+    /**
+     * A part that has the same OneID as {@link #gearboxA} , but a different ObjectID, and belongs to another car.
+     * Used to test that the query matches not only on ObjectID.
+     */
+    PartIdEntityPart gearboxB = generate.partId().toBuilder().oneIDManufacturer(gearboxA.getOneIDManufacturer()).build();
+    PartIdEntityPart gearwheelB = generate.partId();
+
+    /**
+     * A part that has the same ObjectID as {@link #gearboxA} but a different OneID, and belongs to another car.
+     * Used to test that the query matches not only on OneID.
+     */
+    PartIdEntityPart gearboxC = generate.partId().toBuilder().objectIDManufacturer(gearboxA.getObjectIDManufacturer()).build();
+    PartIdEntityPart gearwheelC = generate.partId();
+
+    PartRelationshipEntity carA_gearboxA = generate.partRelationship(carA, gearboxA);
+    PartRelationshipEntity gearboxA_gearwheelA1 = generate.partRelationship(gearboxA, gearwheelA1);
+    PartRelationshipEntity gearboxA_gearwheelA2 = generate.partRelationship(gearboxA, gearwheelA2);
+    PartRelationshipEntity gearboxB_gearwheelB = generate.partRelationship(gearboxB, gearwheelB);
+    PartRelationshipEntity gearboxC_gearwheelC = generate.partRelationship(gearboxC, gearwheelC);
+    PartRelationshipEntity gearwheelA1_screwA1 = generate.partRelationship(gearwheelA1, screwA1);
 
     @Test
-    void getPartsTreeReturnsRelatedEntities() {
+    @DisplayName("The parts tree returns all entities under a vehicle-level part, and no others")
+    void getPartsTreeForCarReturnsRelatedEntities() {
         // Arrange
-        entityManager.persist(car1_gearbox1);
-        entityManager.persist(gearbox1_gearwheel1);
+        persistCarABom();
 
         // Act
-        List<PartRelationshipEntity> partsTree = getPartsTree(car1);
+        List<PartRelationshipEntity> partsTree = getPartsTree(carA);
 
         // Assert
         assertThat(partsTree)
                 .usingRecursiveFieldByFieldElementComparator()
-                .containsExactlyInAnyOrder(car1_gearbox1, gearbox1_gearwheel1);
+                .containsExactlyInAnyOrder(
+                        carA_gearboxA,
+                        gearboxA_gearwheelA1,
+                        gearboxA_gearwheelA2,
+                        gearwheelA1_screwA1);
+    }
+
+    @Test
+    @DisplayName("The parts tree returns all entities under a component-level part, and no others")
+    void getPartsTreeForComponentReturnsRelatedEntities() {
+        // Arrange
+        persistCarABom();
+
+        // Act
+        List<PartRelationshipEntity> partsTree = getPartsTree(gearboxA);
+
+        // Assert
+        assertThat(partsTree)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(
+                        gearboxA_gearwheelA1,
+                        gearboxA_gearwheelA2,
+                        gearwheelA1_screwA1);
+    }
+
+    @Test
+    @DisplayName("The parts tree retrieval only fetches part with matching OneID and ObjectID")
+    void getPartsTreeDoesNotReturnPartsWithOtherOneIdOrObjectId() {
+        // Arrange
+        persistCarABom();
+        // Add entities that would mistakenly end up in the BOM of carA if join fields are wrong
+        entityManager.persist(gearboxB_gearwheelB);
+        entityManager.persist(gearboxC_gearwheelC);
+
+        // Act
+        List<PartRelationshipEntity> partsTree = getPartsTree(carA);
+
+        // Assert
+        assertThat(partsTree)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(
+                        carA_gearboxA,
+                        gearboxA_gearwheelA1,
+                        gearboxA_gearwheelA2,
+                        gearwheelA1_screwA1);
+    }
+
+    @DisplayName("The maxDepth argument must be strictly positive")
+    @ParameterizedTest(name = "For example, maxDepth {0} is not supported")
+    @ValueSource(ints = {-1, -4, 0})
+    void getPartsTreeWithInvalidMaxDepth(int maxDepth) {
+        // The repository doesn't provide data validation, so no exception is thrown.
+        // See https://stackoverflow.com/questions/52914198
+        assertThat(getPartsTree(carA, maxDepth)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("If maxDepth=1, retrieves only direct relations of the queried part")
+    void getPartsTreeWithMaxDepth1() {
+        // Arrange
+        persistCarABom();
+
+        // Act
+        List<PartRelationshipEntity> partsTree = getPartsTree(gearboxA, 1);
+
+        // Assert
+        assertThat(partsTree)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(
+                        gearboxA_gearwheelA1, gearboxA_gearwheelA2);
+    }
+
+    @Test
+    @DisplayName("If maxDepth=2, retrieves only two levels of relations")
+    void getPartsTreeWithMaxDepth2() {
+        // Arrange
+        persistCarABom();
+
+        // Act
+        List<PartRelationshipEntity> partsTree = getPartsTree(carA, 2);
+
+        // Assert
+        assertThat(partsTree)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(
+                        carA_gearboxA,
+                        gearboxA_gearwheelA1,
+                        gearboxA_gearwheelA2);
+    }
+
+    @Test
+    @DisplayName("A cycle of length 0 in the data doesn't yield a crash or duplicates")
+    void getPartsTreeWithCycleOfLength0() {
+        testCycle(gearboxA, gearboxA);
+    }
+
+    @Test
+    @DisplayName("A cycle of length 1 in the data doesn't yield a crash or duplicates")
+    void getPartsTreeWithCycleOfLength1() {
+        testCycle(gearboxA, carA);
+    }
+
+    @Test
+    @DisplayName("A cycle of length 2 in the data doesn't yield a crash or duplicates")
+    void getPartsTreeWithCycleOfLength2() {
+        testCycle(gearwheelA1, carA);
+    }
+
+    @Test
+    @DisplayName("A diamond shape (A->B->C, A->D->C) in the data doesn't yield duplicates")
+    void testDiamond() {
+        persistCarABom();
+        PartIdEntityPart gearbox2 = generate.partId();
+        PartRelationshipEntity carA_gearbox2 = generate.partRelationship(carA, gearbox2);
+        PartRelationshipEntity gearbox2_gearwheelA1 = generate.partRelationship(gearbox2, gearwheelA1);
+        entityManager.persist(carA_gearbox2);
+        entityManager.persist(gearbox2_gearwheelA1);
+
+        // Act
+        List<PartRelationshipEntity> partsTree = getPartsTree(carA);
+
+        // Assert
+        assertThat(partsTree)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(
+                        carA_gearboxA,
+                        gearboxA_gearwheelA1,
+                        gearboxA_gearwheelA2,
+                        gearwheelA1_screwA1,
+                        carA_gearbox2,
+                        gearbox2_gearwheelA1);
+    }
+
+    private void persistCarABom() {
+        entityManager.persist(carA_gearboxA);
+        entityManager.persist(gearboxA_gearwheelA1);
+        entityManager.persist(gearboxA_gearwheelA2);
+        entityManager.persist(gearwheelA1_screwA1);
     }
 
     private List<PartRelationshipEntity> getPartsTree(PartIdEntityPart partId) {
-        return repository.getPartsTree(
+        return getPartsTree(
+                partId,
+                faker.number().numberBetween(10, 1000));
+    }
+
+    private List<PartRelationshipEntity> getPartsTree(PartIdEntityPart partId, int maxDepth) {
+        entityManager.flush();
+        List<PartRelationshipEntity> partsTree = repository.getPartsTree(
                 partId.getOneIDManufacturer(),
                 partId.getObjectIDManufacturer(),
-                faker.number().numberBetween(10, 1000));
+                maxDepth);
+        assertThat(partsTree).doesNotHaveDuplicates();
+        return partsTree;
+    }
+
+    private void testCycle(PartIdEntityPart parent, PartIdEntityPart child) {
+        persistCarABom();
+
+        PartRelationshipEntity cycleEdge = generate.partRelationship(parent, child);
+        entityManager.persist(cycleEdge);
+
+        // Act
+        List<PartRelationshipEntity> partsTree = getPartsTree(carA);
+
+        // Assert
+        assertThat(partsTree)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(
+                        carA_gearboxA,
+                        gearboxA_gearwheelA1,
+                        gearboxA_gearwheelA2,
+                        gearwheelA1_screwA1,
+                        cycleEdge);
     }
 }


### PR DESCRIPTION
Added detailed low-level integration tests for database stored function performing recursive queries.
- The parts tree returns all entities under a vehicle-level part, and no others
- The parts tree returns all entities under a component-level part, and no others
- The parts tree retrieval only fetches part with matching OneID and ObjectID
- The maxDepth argument must be strictly positive
- If maxDepth=1, retrieves only direct relations of the queried part
- If maxDepth=2, retrieves only two levels of relations
- A cycle of length 0 in the data doesn't yield a crash or duplicates
- A cycle of length 1 in the data doesn't yield a crash or duplicates
- A cycle of length 2 in the data doesn't yield a crash or duplicates
- A diamond shape (A->B->C, A->D->C) in the data doesn't yield duplicates