### PR TITLE
Feature/cax 1 semantics@cxmvp 18 semantic hub db connection

### DIFF
--- a/semantics/openapi.yaml
+++ b/semantics/openapi.yaml
@@ -17,24 +17,29 @@ paths:
         - in: query
           name: namespaceFilter
           schema:
+            default: ""
             type: string
         - in: query
           name: nameFilter
           schema:
+            default: ""
             type: string
         - in: query
-          name: isPublic
+          name: isPrivate
           schema:
+            default: false
             type: boolean
         - in: query
           name: type
           schema:
+            default: "BAMM"
             type: string
             enum:
               - BAMM
               - OWL
         - in: query
           name: pageSize
+          required: true
           schema:
             default: 10
             type: integer
@@ -44,8 +49,9 @@ paths:
               - 100
         - in: query
           name: page
+          required: true
           schema:
-            default: 1
+            default: 0
             type: integer
       responses:
         '200':

--- a/semantics/pom.xml
+++ b/semantics/pom.xml
@@ -66,6 +66,16 @@
     </dependencyManagement>
 
     <dependencies>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>42.2.23</version>
+		</dependency>
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>1.4.2.Final</version>
+		</dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -176,6 +186,22 @@
 
 <build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>1.4.2.Final</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
          <plugin>
           <groupId>org.openapitools</groupId>
           <artifactId>openapi-generator-maven-plugin</artifactId>

--- a/semantics/src/main/java/net/catenax/semantics/hub/ModelsService.java
+++ b/semantics/src/main/java/net/catenax/semantics/hub/ModelsService.java
@@ -16,39 +16,44 @@
 
 package net.catenax.semantics.hub;
 
-import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import net.catenax.semantics.hub.api.ModelsApiDelegate;
 import net.catenax.semantics.hub.model.Model;
-import net.catenax.semantics.hub.model.Model.TypeEnum;
+import net.catenax.semantics.hub.persistence.PersistenceLayer;
+import net.catenax.semantics.hub.persistence.mapper.SemanticModelMapper;
+
 @Service
 public class ModelsService implements ModelsApiDelegate {
+    @Autowired
+    PersistenceLayer ps;
+
+    @Autowired
+    SemanticModelMapper mapper;
+
     @Override
-    public ResponseEntity<List<Model>> getModelList(String namespaceFilter,
-        String nameFilter,
-        Boolean isPublic,
-        String type,
-        Integer pageSize,
-        Integer page) {
+    public ResponseEntity<List<Model>> getModelList(Integer pageSize, Integer page, String namespaceFilter,
+            String nameFilter, Boolean isPrivate, String type) {
 
-        Model exampleModel = new Model();
-        exampleModel.setPublisher("ME");
-        exampleModel.setId("1");
-        exampleModel.setName("Aspect");
-        exampleModel.setVersion("1.0.0");
-        exampleModel.setPrivate(true);
-        exampleModel.setType(TypeEnum.BAMM);
-    
+        List<Model> list = mapper.modelEntityListToModelDtoList(
+                ps.getModels(isPrivate, namespaceFilter, nameFilter, type, page, pageSize));
 
-        ArrayList<Model> list = new ArrayList<>();
-
-        list.add(exampleModel);
-        
         return new ResponseEntity<List<Model>>(list, HttpStatus.OK);
+    }
+
+    @Override
+    public ResponseEntity<Model> getModelById(String modelId) {
+        Model model = mapper.modelEntityToModelDto(ps.getModel(modelId));
+
+        if (model == null) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        return new ResponseEntity<Model>(model, HttpStatus.OK);
     }
 }

--- a/semantics/src/main/java/net/catenax/semantics/hub/persistence/ModelRepository.java
+++ b/semantics/src/main/java/net/catenax/semantics/hub/persistence/ModelRepository.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.catenax.semantics.hub.persistence;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import net.catenax.semantics.hub.persistence.model.ModelEntity;
+
+@Repository
+public interface ModelRepository extends JpaRepository<ModelEntity, String> {
+    public ModelEntity getModelById(String id);
+
+    @Query(value = "SELECT m FROM ModelEntity m WHERE m._private = :isPrivate AND m.name LIKE %:nameFilter% AND m.id LIKE %:namespaceFilter% AND m.type = :type")
+    public Page<ModelEntity> filterModels(@Param("isPrivate") boolean isPrivate, @Param("nameFilter") String nameFilter, @Param("namespaceFilter") String namespaceFilter, @Param("type") String type, Pageable pageable);
+}

--- a/semantics/src/main/java/net/catenax/semantics/hub/persistence/PersistenceLayer.java
+++ b/semantics/src/main/java/net/catenax/semantics/hub/persistence/PersistenceLayer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.catenax.semantics.hub.persistence;
+
+import java.util.List;
+
+import net.catenax.semantics.hub.persistence.model.ModelEntity;
+
+public interface PersistenceLayer {
+    public List<ModelEntity> getModels(boolean isPrivate, String namespaceFilter, String nameFilter, String type, int page, int pageSize);
+
+    public ModelEntity getModel(String modelId);
+}

--- a/semantics/src/main/java/net/catenax/semantics/hub/persistence/RDBMSPersistence.java
+++ b/semantics/src/main/java/net/catenax/semantics/hub/persistence/RDBMSPersistence.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.catenax.semantics.hub.persistence;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import net.catenax.semantics.hub.persistence.model.ModelEntity;
+
+
+@Component
+public class RDBMSPersistence implements PersistenceLayer {
+
+    @Autowired
+    ModelRepository mr;
+
+    @Override
+    public List<ModelEntity> getModels(boolean isPrivate, String namespaceFilter, String nameFilter, String type, int page, int pageSize) {
+        Pageable pageOptions = PageRequest.of(page, pageSize);
+
+        Page<ModelEntity> result = mr.filterModels(isPrivate, nameFilter, namespaceFilter, type, pageOptions);
+
+        return result.toList();
+    }
+
+    public ModelEntity getModel(String modelId) {
+        Optional<ModelEntity> result = mr.findById(modelId);
+
+        if(!result.isPresent()) {
+            return null;
+        } else {
+            return result.get();
+        }
+    }
+}

--- a/semantics/src/main/java/net/catenax/semantics/hub/persistence/mapper/SemanticModelMapper.java
+++ b/semantics/src/main/java/net/catenax/semantics/hub/persistence/mapper/SemanticModelMapper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.catenax.semantics.hub.persistence.mapper;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import net.catenax.semantics.hub.model.Model;
+import net.catenax.semantics.hub.persistence.model.ModelEntity;
+
+@Mapper(componentModel = "spring")
+public interface SemanticModelMapper {
+    
+    Model modelEntityToModelDto(ModelEntity model);
+
+    @Mapping(source = "id", target = "id")
+    @Mapping(source = "publisher", target = "publisher")
+    @Mapping(source = "version", target = "version")
+    @Mapping(source = "name", target = "name")
+    @Mapping(source = "_private", target = "_private")
+    @Mapping(source = "type", target = "type")
+    List<Model> modelEntityListToModelDtoList(List<ModelEntity> model);
+}

--- a/semantics/src/main/java/net/catenax/semantics/hub/persistence/model/ModelEntity.java
+++ b/semantics/src/main/java/net/catenax/semantics/hub/persistence/model/ModelEntity.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.catenax.semantics.hub.persistence.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "model")
+public class ModelEntity {
+    @Id
+    private String id;
+
+    private String publisher;
+
+    private String version;
+
+    private String name;
+
+    @Column(name = "private")
+    private Boolean _private;
+
+    private String type;
+
+    private String modelDefinition;
+}

--- a/semantics/src/main/resources/application.properties
+++ b/semantics/src/main/resources/application.properties
@@ -66,11 +66,11 @@ management.endpoints.enabled-by-default=false
 #management.endpoint.logfile.enabled=true
 #management.endpoint.logfile.external-file=./log/semanticslayer.log
 
-### H2 Database
-spring.datasource.url=jdbc:h2:file:./target/db/resources
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=password
+### DB configuration
+spring.datasource.url=jdbc:postgresql://localhost:5432/semantic
+spring.datasource.driverClassName=org.postgresql.Driver
+spring.datasource.username=tractusx
+spring.datasource.password=tractusx
 
 ## Enable H2 Console Access
 spring.h2.console.enabled=true
@@ -81,6 +81,7 @@ spring.h2.console.settings.web-allow-others=true
 #spring.datasource.data=classpath:/data/data.sql
 
 ### Hibernate Properties
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 # spring.jpa.hibernate.naming-strategy=org.hibernate.cfg.DefaultNamingStrategy
 spring.jpa.hibernate.ddl-auto=update
 # spring.jpa.hibernate.ddl-auto=create


### PR DESCRIPTION
This feature extends the (in-memory/mock) semantic hub implementation with a proper persistence layer.

Has been already been successfully portfolio-integrated and tested - see https://github.com/catenax/tractusx/pull/14
