### PR TITLE
Fix hostname in swagger UI

### DIFF
--- a/coreservices/partsrelationshipservice/helm/prs/templates/deployment.yaml
+++ b/coreservices/partsrelationshipservice/helm/prs/templates/deployment.yaml
@@ -24,6 +24,8 @@ spec:
             - containerPort: 4004
               name: actuator
           env:
+            - name: prs.apiUrl
+              value: {{ .Values.prs.apiUrl }}
             - name: spring.datasource.url
               value: {{ .Values.postgresql.url | quote }}
             - name: spring.datasource.username

--- a/coreservices/partsrelationshipservice/terraform/main.tf
+++ b/coreservices/partsrelationshipservice/terraform/main.tf
@@ -61,6 +61,11 @@ resource "helm_release" "prs" {
     value = var.image_tag
   }
 
+  set {
+    name  = "prs.apiUrl"
+    value = "https://${var.ingress_host}"
+  }
+
   set_sensitive {
     name  = "applicationInsights.connectionString"
     value = module.prs_application_insights.connection_string


### PR DESCRIPTION
Requests in Swagger UI were failing with:
```
Failed to fetch.
Possible Reasons:

CORS
Network Failure
URL scheme must be "http" or "https" for CORS request.
```

The following fix instructs springdoc to use the correct hostname in the swagger UI.