### PR TITLE
https://jira.catena-x.net/browse/CATART0PO4-139 

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -136,16 +136,31 @@ jobs:
       uses: actions/checkout@v2
 
     # Initialize terraform 
-    # NOTE: When this is run for the first time, we implictely "change" the initial backend config
-    # so this needs to run twice
-    # NOTE: There are some critical providers and move the critical providers (which would hinder an import-before-apply: kubernetes and helm) away for import
     - name: Terraform Init
+      id: tf_init
       working-directory: ./infrastructure/terraform
       run: | 
-          terraform init -backend-config="key=catenaxdev.tfstateenv:${{needs.environment.outputs.workspace}}" -backend-config="access_key=${{secrets.TFSTATE_STORAGEACCOUNT_KEY}}" -input=false
-          terraform init -backend-config="key=catenaxdev.tfstateenv:${{needs.environment.outputs.workspace}}" -backend-config="access_key=${{secrets.TFSTATE_STORAGEACCOUNT_KEY}}" -input=false
+          terraform init -backend-config="access_key=${{secrets.TFSTATE_STORAGEACCOUNT_KEY}}" -input=false
+          echo "::set-output name=WORKSPACE::$(terraform workspace list | grep "${{needs.environment.outputs.workspace}}")"
+
+    # Create Workspace 
+    # NOTE: There are some critical providers and move the critical providers (which would hinder an import-before-apply: kubernetes and helm) away for import
+    - name: Terraform Workspace Create
+      if: ${{steps.tf_init.outputs.WORKSPACE == '' }}
+      working-directory: ./infrastructure/terraform
+      run: | 
+          terraform workspace new ${{needs.environment.outputs.workspace}}
           mv provider.tf provider.tf_muted
           
+    # Switch Workspace 
+    # NOTE: There are some critical providers and move the critical providers (which would hinder an import-before-apply: kubernetes and helm) away for import
+    - name: Terraform Workspace Select
+      if: ${{steps.tf_init.outputs.WORKSPACE != '' }}
+      working-directory: ./infrastructure/terraform
+      run: | 
+          terraform workspace select ${{needs.environment.outputs.workspace}}
+          mv provider.tf provider.tf_muted
+ 
     # Import shared resources into initial state
     # Only called if we are not in the productive environment (which should be responsible for that resource)
     # TODO: When new shared resources are added, they need to be imported here

--- a/infrastructure/terraform/versions.tf
+++ b/infrastructure/terraform/versions.tf
@@ -25,7 +25,7 @@ terraform {
     resource_group_name  = "terraform-rg"
     storage_account_name = "catenaxdevtfstate"
     container_name       = "tfstate"
-    key                  = "catenaxdev.tfstateenv:${var.environment}"
+    key                  = "catenaxdev.tfstate"
     access_key           = var.azure_storage_access_key
   }
 


### PR DESCRIPTION
Try to cleanup workspace usage.

I do not think that it will solve the complete issue, but the issue of duplicated env suffixes in the state storage blobs should vanish.