### PR TITLE
Link test data ADR in Swagger UI

### DIFF
--- a/coreservices/partsrelationshipservice/api/prs-v0.1.yaml
+++ b/coreservices/partsrelationshipservice/api/prs-v0.1.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.1
 info:
-  description: API to retrieve parts tree information.
+  description: API to retrieve parts tree information. See <a href="https://confluence.catena-x.net/display/CXM/PRS+Environments+and+Test+Data">this
+    page</a> for more information on test data available in this environment.
   title: Catena-X Parts Relationship Service
   version: v0.1
 servers:

--- a/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/configuration/OpenApiConfiguration.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/configuration/OpenApiConfiguration.java
@@ -40,7 +40,7 @@ public class OpenApiConfiguration {
                 .url(prsConfiguration.getApiUrl().toString())
             )
             .info(new Info()
-                .title("Catena-X Parts Relationship Service. ")
+                .title("Catena-X Parts Relationship Service")
                 .version(PrsApplication.API_VERSION)
                 .description("API to retrieve parts tree information. See <a href=\"https://confluence.catena-x.net/display/CXM/PRS+Environments+and+Test+Data\">this page</a> for more information on test data available in this environment.")
             );

--- a/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/configuration/OpenApiConfiguration.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/configuration/OpenApiConfiguration.java
@@ -40,9 +40,9 @@ public class OpenApiConfiguration {
                 .url(prsConfiguration.getApiUrl().toString())
             )
             .info(new Info()
-                .title("Catena-X Parts Relationship Service")
+                .title("Catena-X Parts Relationship Service. ")
                 .version(PrsApplication.API_VERSION)
-                .description("API to retrieve parts tree information.")
+                .description("API to retrieve parts tree information. See <a href=\"https://confluence.catena-x.net/display/CXM/PRS+Environments+and+Test+Data\">this page</a> for more information on test data available in this environment.")
             );
     }
 }


### PR DESCRIPTION
Provide a link in Swagger UI to ADR with information on available test data for each environment.