### PR TITLE
Add Smoke Tests

### DIFF
--- a/.github/workflows/partsrelationshipservice-deploy.yml
+++ b/.github/workflows/partsrelationshipservice-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy PRS
+name: PRS Deploy
 
 on:
   push:

--- a/.github/workflows/partsrelationshipservice-deploy.yml
+++ b/.github/workflows/partsrelationshipservice-deploy.yml
@@ -46,31 +46,3 @@ jobs:
 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
-
-  smoketest:
-    needs: deploy
-    runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        working-directory: coreservices/partsrelationshipservice
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-
-      - name: Cache maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
-      - name: Build with Maven
-        run: |
-          mvn --batch-mode --update-snapshots -Dgroups=SmokeTests test

--- a/.github/workflows/partsrelationshipservice-deploy.yml
+++ b/.github/workflows/partsrelationshipservice-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/CAX-1_PRS@185-smoke-tests
     paths:
       - coreservices/partsrelationshipservice/**
       - .github/workflows/partsrelationshipservice-deploy.yml

--- a/.github/workflows/partsrelationshipservice-deploy.yml
+++ b/.github/workflows/partsrelationshipservice-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feature/CAX-1_PRS@185-smoke-tests
     paths:
       - coreservices/partsrelationshipservice/**
       - .github/workflows/partsrelationshipservice-deploy.yml

--- a/.github/workflows/partsrelationshipservice-deploy.yml
+++ b/.github/workflows/partsrelationshipservice-deploy.yml
@@ -48,7 +48,9 @@ jobs:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
 
   smoketest:
+    needs: deploy
     runs-on: ubuntu-latest
+
     defaults:
       run:
         working-directory: coreservices/partsrelationshipservice

--- a/.github/workflows/partsrelationshipservice-deploy.yml
+++ b/.github/workflows/partsrelationshipservice-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feature/CAX-1_PRS@185-smoke-tests
     paths:
       - coreservices/partsrelationshipservice/**
       - .github/workflows/partsrelationshipservice-deploy.yml
@@ -47,3 +48,28 @@ jobs:
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
 
+  smoketest:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: coreservices/partsrelationshipservice
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Cache maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build with Maven
+        run: |
+          mvn --batch-mode --update-snapshots -Dgroups=SmokeTests test

--- a/.github/workflows/partsrelationshipservice-smoketest.yml
+++ b/.github/workflows/partsrelationshipservice-smoketest.yml
@@ -13,7 +13,6 @@ on:
 
 jobs:
   smoketest:
-    needs: deploy
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/partsrelationshipservice-smoketest.yml
+++ b/.github/workflows/partsrelationshipservice-smoketest.yml
@@ -3,7 +3,7 @@ name: PRS Smoke Test
 on:
   workflow_run:
     workflows: ["PRS Deploy"]
-    branches: [main]
+    branches: [main, feature/CAX-1_PRS@185-smoke-tests]
     types:
       - completed
   workflow_dispatch:

--- a/.github/workflows/partsrelationshipservice-smoketest.yml
+++ b/.github/workflows/partsrelationshipservice-smoketest.yml
@@ -3,7 +3,7 @@ name: PRS Smoke Test
 on:
   workflow_run:
     workflows: ["PRS Deploy"]
-    branches: [main, "feature/CAX-1_PRS@185-smoke-tests"]
+    branches: [main]
     types:
       - completed
   workflow_dispatch:

--- a/.github/workflows/partsrelationshipservice-smoketest.yml
+++ b/.github/workflows/partsrelationshipservice-smoketest.yml
@@ -1,9 +1,6 @@
 name: PRS Smoke Test
 
 on:
-  push:
-    branches:
-      - feature/CAX-1_PRS@185-smoke-tests
   workflow_run:
     workflows: ["PRS Deploy"]
     branches: [main]

--- a/.github/workflows/partsrelationshipservice-smoketest.yml
+++ b/.github/workflows/partsrelationshipservice-smoketest.yml
@@ -1,4 +1,4 @@
-name: Deploy PRS
+name: PRS Smoke Test
 
 on:
   workflow_run:

--- a/.github/workflows/partsrelationshipservice-smoketest.yml
+++ b/.github/workflows/partsrelationshipservice-smoketest.yml
@@ -3,13 +3,14 @@ name: PRS Smoke Test
 on:
   workflow_run:
     workflows: ["PRS Deploy"]
-    branches: [main, feature/CAX-1_PRS@185-smoke-tests]
+    branches: [main, "feature/CAX-1_PRS@185-smoke-tests"]
     types:
       - completed
   workflow_dispatch:
 
 jobs:
   smoketest:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/partsrelationshipservice-smoketest.yml
+++ b/.github/workflows/partsrelationshipservice-smoketest.yml
@@ -1,0 +1,38 @@
+name: Deploy PRS
+
+on:
+  workflow_run:
+    workflows: ["Deploy PRS"]
+    branches: [main]
+    types:
+      - completed
+  workflow_dispatch:
+
+jobs:
+  smoketest:
+    needs: deploy
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: coreservices/partsrelationshipservice
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Cache maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build with Maven
+        run: |
+          mvn --batch-mode --update-snapshots -Dgroups=SmokeTests test

--- a/.github/workflows/partsrelationshipservice-smoketest.yml
+++ b/.github/workflows/partsrelationshipservice-smoketest.yml
@@ -1,6 +1,9 @@
 name: PRS Smoke Test
 
 on:
+  push:
+    branches:
+      - feature/CAX-1_PRS@185-smoke-tests
   workflow_run:
     workflows: ["PRS Deploy"]
     branches: [main]

--- a/.github/workflows/partsrelationshipservice-smoketest.yml
+++ b/.github/workflows/partsrelationshipservice-smoketest.yml
@@ -2,7 +2,7 @@ name: PRS Smoke Test
 
 on:
   workflow_run:
-    workflows: ["Deploy PRS"]
+    workflows: ["PRS Deploy"]
     branches: [main]
     types:
       - completed

--- a/coreservices/partsrelationshipservice/integration-tests/pom.xml
+++ b/coreservices/partsrelationshipservice/integration-tests/pom.xml
@@ -16,6 +16,10 @@
     <name>PRS Tests</name>
     <description>Part Relationship Service Integration Tests</description>
 
+    <properties>
+        <groups>IntegrationTests</groups>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>net.catenax.prs</groupId>
@@ -59,6 +63,13 @@
                 <artifactId>maven-install-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <groups>${groups}</groups>
                 </configuration>
             </plugin>
         </plugins>

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/test/PrsIntegrationTestsBase.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/test/PrsIntegrationTestsBase.java
@@ -13,6 +13,7 @@ import io.restassured.RestAssured;
 import net.catenax.prs.PrsApplication;
 import net.catenax.prs.configuration.PrsConfiguration;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
@@ -21,6 +22,7 @@ import org.springframework.test.context.TestPropertySource;
 import static net.catenax.prs.testing.TestUtil.DATABASE_TESTCONTAINER;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
+@Tag("IntegrationTests")
 @TestPropertySource(properties = DATABASE_TESTCONTAINER)
 @SpringBootTest(classes = {PrsApplication.class}, webEnvironment = RANDOM_PORT)
 public class PrsIntegrationTestsBase {

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/test/SmokeTests.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/test/SmokeTests.java
@@ -35,7 +35,6 @@ public class SmokeTests {
     @BeforeEach
     public void setUp() {
         RestAssured.baseURI = "https://catenaxdev001akssrv.germanywestcentral.cloudapp.azure.com";
-        RestAssured.port = 443;
     }
 
     @Test

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/test/SmokeTests.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/test/SmokeTests.java
@@ -1,0 +1,55 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
+package net.catenax.prs.test;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static com.catenax.partsrelationshipservice.dtos.PartsTreeView.AS_MAINTAINED;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Smoke tests verify that the cloud infrastructure where PRS runs is working as expected
+ * @see <a href="https://confluence.catena-x.net/display/CXM/PRS+Testing+Strategy">PRS Testing Strategy</a>
+ */
+@Tag("SmokeTests")
+public class SmokeTests {
+
+    private static final String PATH = "/api/v0.1/vins/{vin}/partsTree";
+    private static final String SAMPLE_VIN = "YS3DD78N4X7055320";
+    private static final String VIN = "vin";
+    private static final String VIEW = "view";
+
+    @BeforeEach
+    public void setUp() {
+        RestAssured.baseURI = "https://catenaxdev001akssrv.germanywestcentral.cloudapp.azure.com";
+        RestAssured.port = 443;
+    }
+
+    @Test
+    public void getPartsTreeByVin_success() {
+        given()
+            .pathParam(VIN, SAMPLE_VIN)
+            .queryParam(VIEW, AS_MAINTAINED)
+        .when()
+            .get(PATH)
+        .then()
+            .assertThat()
+            .statusCode(HttpStatus.OK.value())
+            .body("relationships", hasSize(greaterThan(0)))
+            .body("partInfos", hasSize(greaterThan(0)));
+    }
+
+}


### PR DESCRIPTION
This PR introduces a Smoke Test running against the PRS instance in the DEV environment. The Smoke Test is run by a dedicated workflow (allowing to run it manually and if desired on a schedule at a later point in time) and it is automatically triggered after successful run of the deploy workflow.

Example of successful run:
https://github.com/catenax/tractusx/actions/runs/1282912826