### PR TITLE
Fix aspect url

### DIFF
--- a/data/tdm/generator/src/main/java/com/catenax/tdm/aspect/AspectFactory.java
+++ b/data/tdm/generator/src/main/java/com/catenax/tdm/aspect/AspectFactory.java
@@ -86,7 +86,7 @@ public class AspectFactory {
 	 * @return the aspect URL
 	 */
 	public static String getAspectURL() {
-		final String result = Config.BASE_URL + "/catena-x/tdm/aspect/";
+		final String result = Config.BASE_URL + "/catena-x/tdm/1.0/aspect/";
 
 		return result;
 	}

--- a/data/tdm/generator/src/main/java/io/swagger/api/CatenaXApiController.java
+++ b/data/tdm/generator/src/main/java/io/swagger/api/CatenaXApiController.java
@@ -97,7 +97,7 @@ public class CatenaXApiController implements CatenaXApi {
 			@Parameter(in = ParameterIn.QUERY, description = "number of vehicles to create", schema = @Schema()) @Valid @RequestParam(value = "count", required = false) Integer count,
 			@Parameter(in = ParameterIn.QUERY, description = "Vehicle Type", schema = @Schema()) @Valid @RequestParam(value = "vehicleType", required = false) String vehicleType) {
 
-		final String baseUrl = (System.getenv("TDM_HOST_SECURE") == "false" ? "http://" : "https://")
+		final String baseUrl = ("false".equals(System.getenv("TDM_HOST_SECURE"))  ? "http://" : "https://")
 				+ System.getenv("TDM_HOST_NAME") + ":" + System.getenv("TDM_HOST_PORT");
 		Config.BASE_URL = baseUrl;
 


### PR DESCRIPTION
Fix generated aspect URLs:
- URLs should contain version
- Additionally the TDG needs to be redeployed with `TDM_HOST_SECURE=false` in order for the generator to create http:// links (see code [here](https://github.com/catenax/tractusx/blob/main/data/tdm/generator/src/main/java/io/swagger/api/CatenaXApiController.java#L100))
