### PR TITLE
Restrict artifact access to one consumer when creating it.

### DIFF
--- a/coreservices/partsrelationshipservice/connectors_scripts/README.md
+++ b/coreservices/partsrelationshipservice/connectors_scripts/README.md
@@ -31,7 +31,7 @@ pipenv shell
 "https://catenaxdev001akssrv.germanywestcentral.cloudapp.azure.com" \
 <username> \
 <password>
-<consumer-url> # consumer that should have access to the artifact.
+<consumer-url> # consumer that should be given access to the artifact.
 ```
 
 The created artifact will be only accessible by the consumer specified in <consumer-url>. Other consumers will not be able to access the resource.

--- a/coreservices/partsrelationshipservice/connectors_scripts/README.md
+++ b/coreservices/partsrelationshipservice/connectors_scripts/README.md
@@ -31,7 +31,12 @@ pipenv shell
 "https://catenaxdev001akssrv.germanywestcentral.cloudapp.azure.com" \
 <username> \
 <password>
+<consumer-url> # consumer that should have access to the artifact.
 ```
+
+The created artifact will be only accessible by the consumer specified in <consumer-url>. Other consumers will not be able to access the resource.
+The script creates a rule that specifies that only this consumer can access the artifact. 
+Rules are based on consumer-id. In our system, consumer ids are consumer urls.
 
 ## Negotiate contract and consume the data of an artifact
 
@@ -46,6 +51,7 @@ pipenv shell
 <pathparams-and-query-params-to-append-to-the-url-to-access-a-specific-resource> \
 <username> \
 <password>
+"https://catenaxdev006akssrv.germanywestcentral.cloudapp.azure.com/kaputt/consumer"
 ```
 
 ## Negotiate contract and consume the data of an artifact in the env001 environment

--- a/coreservices/partsrelationshipservice/connectors_scripts/README.md
+++ b/coreservices/partsrelationshipservice/connectors_scripts/README.md
@@ -5,6 +5,10 @@ This document explains how we can create an artifact and consume the data of the
 
 ## Create a catalog and an artifact
 
+The created artifact will be only accessible by the consumer specified in <consumer-url>. Other consumers will not be able to access the resource.
+The script creates a rule that specifies that only this consumer can access the artifact.
+Rules are based on consumer-id. In our system, consumer ids are consumer urls.
+
 ```bash
 pipenv sync
 pipenv shell
@@ -16,6 +20,7 @@ pipenv shell
 <access-url-to-access-the-artifact> \
 <username> \
 <password>
+<consumer-url> # consumer that should be given access to the artifact.
 ```
 
 ## Create a catalog and an artifact in the dev001 environment
@@ -31,12 +36,8 @@ pipenv shell
 "https://catenaxdev001akssrv.germanywestcentral.cloudapp.azure.com" \
 <username> \
 <password>
-<consumer-url> # consumer that should be given access to the artifact.
+"https://catenaxdev006akssrv.germanywestcentral.cloudapp.azure.com/kaputt/consumer"
 ```
-
-The created artifact will be only accessible by the consumer specified in <consumer-url>. Other consumers will not be able to access the resource.
-The script creates a rule that specifies that only this consumer can access the artifact. 
-Rules are based on consumer-id. In our system, consumer ids are consumer urls.
 
 ## Negotiate contract and consume the data of an artifact
 
@@ -51,7 +52,6 @@ pipenv shell
 <pathparams-and-query-params-to-append-to-the-url-to-access-a-specific-resource> \
 <username> \
 <password>
-"https://catenaxdev006akssrv.germanywestcentral.cloudapp.azure.com/kaputt/consumer"
 ```
 
 ## Negotiate contract and consume the data of an artifact in the env001 environment

--- a/coreservices/partsrelationshipservice/connectors_scripts/create_catalog_and_artifact.py
+++ b/coreservices/partsrelationshipservice/connectors_scripts/create_catalog_and_artifact.py
@@ -40,9 +40,8 @@ access_url = sys.argv[5]
 # User having an access to the  provider connector.
 user = sys.argv[6]
 password = sys.argv[7]
-
-print("Setting provider url:", provider_url)
-print("Setting provider alias as:", provider_alias)
+# Consumer id to restrict access only to this consumer
+consumer_id = sys.argv[8]
 
 # Suppress ssl verification warning
 requests.packages.urllib3.disable_warnings()
@@ -64,7 +63,41 @@ artifact = provider.create_artifact(data=
 })
 
 contract = provider.create_contract()
-use_rule = provider.create_rule()
+rule_definition={"value": f"""{{
+                "@context" : {{
+                  "ids" : "https://w3id.org/idsa/core/",
+                  "idsc" : "https://w3id.org/idsa/code/"
+                }},
+                "@type" : "ids:Permission",
+                "@id" : "https://w3id.org/idsa/autogen/permission/d504b82f-79dd-4c93-969d-937ab6a1d676",
+                "ids:description" : [ {{
+                  "@value" : "connector-restriction",
+                  "@type" : "http://www.w3.org/2001/XMLSchema#string"
+                }} ],
+                "ids:title" : [ {{
+                  "@value" : "PRS access Policy",
+                  "@type" : "http://www.w3.org/2001/XMLSchema#string"
+                }} ],
+                "ids:action" : [ {{
+                  "@id" : "idsc:USE"
+                }} ],
+                "ids:constraint" : [ {{
+                  "@type" : "ids:Constraint",
+                  "@id" : "https://w3id.org/idsa/autogen/constraint/572c96ec-dd86-4b20-a849-a0ce8c255eee",
+                  "ids:rightOperand" : {{
+                    "@value" : "{consumer_id}",
+                    "@type" : "http://www.w3.org/2001/XMLSchema#anyURI"
+                  }},
+                  "ids:leftOperand" : {{
+                    "@id" : "idsc:SYSTEM"
+                  }},
+                  "ids:operator" : {{
+                    "@id" : "idsc:SAME_AS"
+                  }}
+                }} ]
+              }}"""}
+
+use_rule = provider.create_rule(data=rule_definition)
 
 ## Link resources
 provider.add_resource_to_catalog(catalog, offers)

--- a/coreservices/partsrelationshipservice/connectors_scripts/create_catalog_and_artifact.py
+++ b/coreservices/partsrelationshipservice/connectors_scripts/create_catalog_and_artifact.py
@@ -63,6 +63,10 @@ artifact = provider.create_artifact(data=
 })
 
 contract = provider.create_contract()
+
+# In the rule definition, ids:constraint should be read in the following order:
+# ids:leftOperand ids:operand ids:rightOperand. In our case it means:
+# SYSTEM SAME_AS consumer_id
 rule_definition={"value": f"""{{
                 "@context" : {{
                   "ids" : "https://w3id.org/idsa/core/",

--- a/coreservices/partsrelationshipservice/connectors_scripts/create_catalog_and_artifact.py
+++ b/coreservices/partsrelationshipservice/connectors_scripts/create_catalog_and_artifact.py
@@ -64,6 +64,8 @@ artifact = provider.create_artifact(data=
 
 contract = provider.create_contract()
 
+# ids:constraint and ids:Permission must have an @id, that can be any URL. The content of the @id does not have
+# any impact.
 # In the rule definition, ids:constraint should be read in the following order:
 # ids:leftOperand ids:operand ids:rightOperand. In our case it means:
 # SYSTEM SAME_AS consumer_id


### PR DESCRIPTION
This script is inspired from the following [Dataspace connector script](https://github.com/International-Data-Spaces-Association/DataspaceConnector/blob/24195cf3ffdb3a3194d29f7483e8526ea78bfbd1/scripts/tests/contract_negotation_connector_restricted_access.py).
I am leaving this PR as a draft because I want to clarify details about the rules with Dataspace connector developers.

It was tested in the following way:
- Created an artifact with access restricted. Only Kaputt consumer can access the resource:
```bash
 ./create_catalog_and_artifact.py \                         
"https://catenaxdev006akssrv.germanywestcentral.cloudapp.azure.com/prs/upload" \
"https://catenaxdev006akssrv.germanywestcentral.cloudapp.azure.com/prs/upload" \
"PRS catalog" \
"PRS" \
"https://catenaxdev001akssrv.germanywestcentral.cloudapp.azure.com" \
<username> \
<password> \
"https://catenaxdev006akssrv.germanywestcentral.cloudapp.azure.com/kaputt/consumer"
```

Tried to negotiate the contract and access the resource with the prs consumer:
```bash
./negotiate_contract_and_consume_artifact.py \                                                
"https://catenaxdev006akssrv.germanywestcentral.cloudapp.azure.com/prs/upload" \
"https://catenaxdev006akssrv.germanywestcentral.cloudapp.azure.com/prs/query" \
"https://catenaxdev006akssrv.germanywestcentral.cloudapp.azure.com/prs/upload" \
"https://catenaxdev006akssrv.germanywestcentral.cloudapp.azure.com/prs/query" \
"/api/v0.1/vins/YS3DD78N4X7055320/partsTree?view=AS_BUILT" \
<username> \
<password>
```

Accessing the data fails with this message: `'{"message":"A policy restriction has been detected."}'`.
This is expected as the PRS consumer does not have access to the artifact. But Kaputt has access.