### PR TITLE
Fix getByVIN endpoint

### DIFF
--- a/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/configuration/PrsConfiguration.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/configuration/PrsConfiguration.java
@@ -35,7 +35,7 @@ public class PrsConfiguration {
      * which indicates that the {@link PartIdEntityPart#getObjectIDManufacturer()} value is a VIN
      * (Vehicle Identification Number). This is used to query the part tree by VIN.
      */
-    public static final String VEHICLE_ATTRIBUTE_VALUE = "Vehicle";
+    public static final String VEHICLE_ATTRIBUTE_VALUE = "vehicle";
 
     /**
      * The Base URL at which the API is externally accessible. Used in generated OpenAPI definition.

--- a/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/services/PartsTreeQueryByVinService.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/services/PartsTreeQueryByVinService.java
@@ -63,7 +63,7 @@ public class PartsTreeQueryByVinService {
                 PartAttributeEntity.builder()
                         .key(getPartInformationKey(vin))
                         .value(PrsConfiguration.VEHICLE_ATTRIBUTE_VALUE).build(),
-                        ExampleMatcher.matching().withIgnoreCase());
+                        ExampleMatcher.matching().withIgnoreCase("value"));
         final var vehicles = attributeRepository.findAll(searchFilter, SORTED_BY_ONEID);
         if (vehicles.isEmpty()) {
             throw new EntityNotFoundException(MessageFormat.format(ApiErrorsConstants.VEHICLE_NOT_FOUND_BY_VIN, request.getVin()));

--- a/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/services/PartsTreeQueryByVinService.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/services/PartsTreeQueryByVinService.java
@@ -22,6 +22,7 @@ import net.catenax.prs.repositories.PartAttributeRepository;
 import net.catenax.prs.requests.PartsTreeByObjectIdRequest;
 import net.catenax.prs.requests.PartsTreeByVinRequest;
 import org.springframework.data.domain.Example;
+import org.springframework.data.domain.ExampleMatcher;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
@@ -61,7 +62,8 @@ public class PartsTreeQueryByVinService {
         final var searchFilter = Example.of(
                 PartAttributeEntity.builder()
                         .key(getPartInformationKey(vin))
-                        .value(PrsConfiguration.VEHICLE_ATTRIBUTE_VALUE).build());
+                        .value(PrsConfiguration.VEHICLE_ATTRIBUTE_VALUE).build(),
+                        ExampleMatcher.matching().withIgnoreCase());
         final var vehicles = attributeRepository.findAll(searchFilter, SORTED_BY_ONEID);
         if (vehicles.isEmpty()) {
             throw new EntityNotFoundException(MessageFormat.format(ApiErrorsConstants.VEHICLE_NOT_FOUND_BY_VIN, request.getVin()));


### PR DESCRIPTION
The TDG generates the vehicle attribute names lowercase, but the code expects it to be uppercase. To make the PRS more robust the comparison is made ignoring case.