### PR TITLE
Use new artifact in dev006 smoke tests

### DIFF
--- a/.github/workflows/partsrelationshipservice-smoketest.yml
+++ b/.github/workflows/partsrelationshipservice-smoketest.yml
@@ -12,7 +12,7 @@ jobs:
   smoketest:
     env:
       PRS_BASEURI: "https://catenaxdev001akssrv.germanywestcentral.cloudapp.azure.com"
-      KAPUTT_DEV_CONSUMER_ARTIFACT_URI: "https://catenaxdev006akssrv.germanywestcentral.cloudapp.azure.com/kaputt/consumer/api/artifacts/f340deb6-e666-493e-a7d2-f9101192b6ed/data"
+      KAPUTT_DEV_CONSUMER_ARTIFACT_URI: "https://catenaxdev006akssrv.germanywestcentral.cloudapp.azure.com/kaputt/consumer/api/artifacts/2922a713-61c7-49a1-bbae-114b6a1ad9d8/data"
       KAPUTT_INT_CONSUMER_ARTIFACT_URI: "https://catenaxintakssrv.germanywestcentral.cloudapp.azure.com/kaputt/consumer/api/artifacts/8e46b415-8611-489f-82a4-2e057058adfa/data"
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'}}
     runs-on: ubuntu-latest


### PR DESCRIPTION
The artifact id was re-created in dev006 in order to only provide access to Kaputt
This broke the smoke tests, we should use the new artifact.
Smoke test run => https://github.com/catenax/tractusx/actions/runs/1315775179