### PR TITLE
PRS: CI pipeline checks terraform formatting

### DIFF
--- a/coreservices/partsrelationshipservice/terraform/main.tf
+++ b/coreservices/partsrelationshipservice/terraform/main.tf
@@ -5,7 +5,7 @@
 module "prs_application_insights" {
   source = "./modules/application-insights"
 
-  name                 = "${var.prefix}-${var.environment}-prs-appi"
+  name                = "${var.prefix}-${var.environment}-prs-appi"
   resource_group_name = local.resource_group_name
   location            = local.location
 }


### PR DESCRIPTION
Fail the CI build (with a clear diff) if terraform files are not formatted as per output of `terraform fmt`.
This reduces spurious diffs