### PR TITLE
E2E test for PartRelationship update

### DIFF
--- a/coreservices/partsrelationshipservice/integration-tests/pom.xml
+++ b/coreservices/partsrelationshipservice/integration-tests/pom.xml
@@ -34,6 +34,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>net.catenax.prs</groupId>
+            <artifactId>broker-proxy</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>4.4.0</version>

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/e2etest/E2EPrsTests.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/e2etest/E2EPrsTests.java
@@ -1,0 +1,93 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
+package net.catenax.prs.e2etest;
+
+import com.catenax.partsrelationshipservice.dtos.*;
+import com.github.javafaker.Faker;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import net.catenax.brokerproxy.requests.PartRelationshipUpdate;
+import net.catenax.brokerproxy.requests.PartRelationshipUpdateRequest;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import java.time.Instant;
+import java.util.List;
+
+import static com.catenax.partsrelationshipservice.dtos.PartsTreeView.AS_MAINTAINED;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Smoke tests verify that the cloud infrastructure where PRS runs is working as expected
+ * @see <a href="https://confluence.catena-x.net/display/CXM/PRS+Testing+Strategy">PRS Testing Strategy</a>
+ */
+public class E2EPrsTests extends E2ETestBase {
+
+    private Faker faker = new Faker();
+
+    @Test
+    @Disabled
+    public void updateRelationshipsAndGetPartsTree_success() {
+
+        RequestSpecification specification = getRequestSpecification();
+
+        PartId child = PartId.builder()
+                .withOneIDManufacturer(faker.company().name())
+                .withObjectIDManufacturer(faker.lorem().characters(10, 20))
+                .build();
+        PartId parent = PartId.builder()
+                .withOneIDManufacturer(faker.company().name())
+                .withObjectIDManufacturer(faker.lorem().characters(10, 20))
+                .build();
+        PartRelationship partRelationship = PartRelationship.builder()
+                .withParent(parent)
+                .withChild(child)
+                .build();
+        var updateRequest = PartRelationshipUpdateRequest.builder()
+                .withRelationships(List.of(
+                        PartRelationshipUpdate.builder()
+                                .withEffectTime(Instant.now())
+                                .withRemove(false)
+                                .withStage(PartLifecycleStage.BUILD)
+                                .withRelationship(partRelationship)
+                                .build()))
+                .build();
+
+        given()
+            .contentType(ContentType.JSON)
+            .pathParam(ONE_ID_MANUFACTURER, parent.getOneIDManufacturer())
+            .pathParam(OBJECT_ID_MANUFACTURER, parent.getObjectIDManufacturer())
+            .queryParam(VIEW, PartsTreeView.AS_MAINTAINED)
+            .body(updateRequest)
+        .when()
+            .post(PATH_UPDATE_ATTRIBUTES)
+        .then()
+            .assertThat()
+            .statusCode(HttpStatus.NO_CONTENT.value());
+
+        var response =
+            given()
+                .spec(specification)
+                .pathParam(VIN, SAMPLE_VIN)
+                .queryParam(VIEW, AS_MAINTAINED)
+            .when()
+                .get(PATH_BY_IDS)
+            .then()
+                .assertThat()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(PartRelationshipsWithInfos.class);
+
+        assertThat(response.getRelationships()).containsOnly(partRelationship);
+    }
+
+}

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/e2etest/E2ETestBase.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/e2etest/E2ETestBase.java
@@ -1,0 +1,47 @@
+package net.catenax.prs.e2etest;
+
+import io.restassured.RestAssured;
+import io.restassured.authentication.BasicAuthScheme;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
+
+public class E2ETestBase {
+
+    protected static final String PATH_BY_VIN = "/api/v0.1/vins/{vin}/partsTree";
+    protected static final String PATH_BY_IDS = "/api/v0.1/parts/{oneIDManufacturer}/{objectIDManufacturer}/partsTree";
+    protected static final String PATH_UPDATE_ATTRIBUTES = "/broker-proxy/v0.1/partRelationshipUpdateList";
+
+    protected static final String SAMPLE_VIN = "YS3DD78N4X7055320";
+    protected static final String VIN = "vin";
+    protected static final String VIEW = "view";
+    protected static final String ONE_ID_MANUFACTURER = "oneIDManufacturer";
+    protected static final String OBJECT_ID_MANUFACTURER = "objectIDManufacturer";
+    protected String userName;
+    protected String password;
+
+
+    @BeforeEach
+    public void setUp() {
+        // If no config specified, run the smoke test against the service deployed in dev001.
+        RestAssured.baseURI = System.getProperty("baseURI") == null ?
+                "https://catenaxdev001akssrv.germanywestcentral.cloudapp.azure.com" : System.getProperty("baseURI");
+        userName = System.getProperty("userName");
+        password = System.getProperty("password");
+
+    }
+
+    protected RequestSpecification getRequestSpecification() {
+        var specificationBuilder = new RequestSpecBuilder();
+
+        // Add basic auth if a userName and password have been specified.
+        if (userName != null && password != null) {
+            var auth = new BasicAuthScheme();
+            auth.setUserName(userName);
+            auth.setPassword(password);
+            specificationBuilder.setAuth(auth).build();
+        }
+
+        return specificationBuilder.build();
+    }
+}

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/smoketest/SmokeTests.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/smoketest/SmokeTests.java
@@ -9,10 +9,9 @@
 //
 package net.catenax.prs.smoketest;
 
-import io.restassured.RestAssured;
 import io.restassured.authentication.BasicAuthScheme;
 import io.restassured.builder.RequestSpecBuilder;
-import org.junit.jupiter.api.BeforeEach;
+import net.catenax.prs.e2etest.E2ETestBase;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -27,23 +26,7 @@ import static org.hamcrest.Matchers.hasSize;
  * @see <a href="https://confluence.catena-x.net/display/CXM/PRS+Testing+Strategy">PRS Testing Strategy</a>
  */
 @Tag("SmokeTests")
-public class SmokeTests {
-
-    private static final String PATH = "/api/v0.1/vins/{vin}/partsTree";
-    private static final String SAMPLE_VIN = "YS3DD78N4X7055320";
-    private static final String VIN = "vin";
-    private static final String VIEW = "view";
-    private String userName;
-    private String password;
-
-    @BeforeEach
-    public void setUp() {
-        // If no config specified, run the smoke test against the service deployed in dev001.
-        RestAssured.baseURI = System.getProperty("baseURI") == null ?
-                "https://catenaxdev001akssrv.germanywestcentral.cloudapp.azure.com" : System.getProperty("baseURI");
-        userName = System.getProperty("userName");
-        password = System.getProperty("password");
-    }
+public class SmokeTests extends E2ETestBase {
 
     @Test
     public void getPartsTreeByVin_success() {
@@ -65,7 +48,7 @@ public class SmokeTests {
             .pathParam(VIN, SAMPLE_VIN)
             .queryParam(VIEW, AS_MAINTAINED)
         .when()
-            .get(PATH)
+            .get(PATH_BY_VIN)
         .then()
             .assertThat()
             .statusCode(HttpStatus.OK.value())


### PR DESCRIPTION
- new package created for e2e tests.
- added class E2EPrsTests with 1 test that covers scenario for PartRelationship creation, the result is tested using PRS API
- E2EBaseTest class extracted to store commons for both SmokeTests and E2EPrsTests
- new E2E reuses the SmokeTest set up and runs on dev006 env

open points:
- should we handle the data removal after the test? 
- should we use existing part to avoid creating new parts on dev?  