### PR TITLE
Fix duplicated VIN generation

### DIFF
--- a/data/tdm/generator/src/main/java/com/catenax/tdm/TestDataGenerator.java
+++ b/data/tdm/generator/src/main/java/com/catenax/tdm/TestDataGenerator.java
@@ -127,7 +127,8 @@ public class TestDataGenerator {
 	 * @return the char
 	 */
 	public static char randChar() {
-		// ThreadLocalRandom must not be stored in a static variable
+		// ThreadLocalRandom.current() must not be stored in a static variable so that the
+		// correct random number generator instance is fetched for the current thread
 		Random random = ThreadLocalRandom.current();
 		final int i = random.nextInt(symbols.length);
 		return symbols[i];


### PR DESCRIPTION
`ThreadLocalRandom.current()` was being stored in a static variable causing VINs not to be generated randomly as expected