### PR TITLE
Feature/cax 1 prs@Increased readiness liveness failure threshold of PRS API

### DIFF
--- a/coreservices/partsrelationshipservice/helm/prs/templates/deployment.yaml
+++ b/coreservices/partsrelationshipservice/helm/prs/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
               port: actuator
             periodSeconds: 3
             timeoutSeconds: 1
-            failureThreshold: 90
+            failureThreshold: 30
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Deployment fails because readiness and liveness endpoints are ready too late.
Increasing the failure threshold to not fail deployment when deployment is slow.
Successful deployment: https://github.com/catenax/tractusx/actions/runs/1346009996