### PR TITLE
Implement small findings for Digital Twin Registry and  Semantic Hub UI

### DIFF
--- a/portal/code/tractus-x-portal/src/components/digitaltwins/digitaltwindetail.tsx
+++ b/portal/code/tractus-x-portal/src/components/digitaltwins/digitaltwindetail.tsx
@@ -25,45 +25,44 @@ export function DigitalTwinDetail(props){
       <BackLink history={props.history} />
       {twin ?
         <div className='m5 p20 bgpanel flex40 br4 bsdatacatalog'>
-          <h2 className='fs24 bold'>{twin.id}</h2>
-          <span className='fs14 pt8'>{twin.description}</span>
+          <h2 className='fs24 bold'>{twin.description}</h2>
           <div className='mt20 mb30'>
             <DescriptionList title="Manufacturer" description={twin.manufacturer} />
+            <div className='mt20'>
+            <h3 className="fs20 bold">Local Identifiers</h3>
+            {twin.localIdentifiers.map(identifier => (
+              <div className='mt20'>
+                <DescriptionList title="Key" description={identifier.key}/>
+                <DescriptionList title="Value" description={identifier.value}/>
+              </div>
+            ))}
+            </div>
             <h3 className='fs20 bold mt20'>Aspects</h3>
-            {twin.aspects.map(aspect => (
-              <div key={aspect.id} className="mb15 mt15 bbw1 bbss fgtab pb20">
-                <DescriptionList title="ID" description={aspect.id} />
+            {twin.aspects.map( (aspect, index) => (
+              <div key={aspect.id} className={`mb15 mt25 bbss fgtab pb20 ${index === (twin.aspects.length -1) ? '' : 'bbw1'}`}>
                 <dl>
-                  <dt className='dib minw150 fs14 fggrey'>Model Reference URN</dt>
+                  <h4 className='dib minw150 fs14'>Model Reference URN</h4>
                   <dd className='fs14 fg5a dib'>
-                    <Link className="mr20" to={{
+                    <Link className="ml25" to={{
                       pathname: `/home/semanticmodel/${aspect.modelReference.urn.replace("#","%23")}`,
                       state: aspect.modelReference.urn
                     }}>{aspect.modelReference.urn}</Link>
                   </dd>
                 </dl>
-                <h4 className="dib mt20 fs14">HTTP Endpoints</h4>
+                <h4 className="dib mt20 fs14">Endpoints</h4>
                 {aspect.httpEndpoints.map(httpEp => (
-                  <div key={httpEp.id} className="ml20 mt10">
-                    <DescriptionList title="ID" description={httpEp.id}/>
-                    <DescriptionList title="Method" description={httpEp.method}/>
+                  <div key={httpEp.id} className="ml25 mt10">
                     <dl>
                       <dt className='dib minw150 fs14 fggrey'>URL</dt>
                       <dd className='fs14 fg5a dib'>
                         <Link className="mr20" to={{
                           pathname: `/home/aspect/${httpEp.url}`
-                        }}>{httpEp.url}</Link>
+                        }}>Aspect IDS Connector URL</Link>
                       </dd>
                     </dl>
+                    <DescriptionList title="Method" description={httpEp.method}/>
                   </div>
                 ))}
-              </div>
-            ))}
-            <h3 className="fs20 bold mb20">Local Identifiers</h3>
-            {twin.localIdentifiers.map(identifier => (
-              <div>
-                <DescriptionList title="Key" description={identifier.key}/>
-                <DescriptionList title="Value" description={identifier.value}/>
               </div>
             ))}
           </div>

--- a/portal/code/tractus-x-portal/src/components/digitaltwins/digitaltwins.tsx
+++ b/portal/code/tractus-x-portal/src/components/digitaltwins/digitaltwins.tsx
@@ -112,11 +112,10 @@ export default class DigitalTwins extends React.Component<DigitalTwin, any>{
                   <Link key={twin.id} className="m5 p20 bgpanel flex40 br4 bsdatacatalog tdn" to={{
                     pathname: `/home/digitaltwin/${twin.id}`
                   }}>
-                    <h2 className='fs24 fg191 bold'>{twin.id}</h2>
-                    <p className='fs14 fg191 pt8 mb20'>{twin.description}</p>
+                    <h2 className='fs24 fg191 bold mb20'>{twin.description}</h2>
                     <DescriptionList title="Manufacturer:" description={twin.manufacturer}/>
-                    <DescriptionList title="Aspects count:" description={twin.localIdentifiers.length}/>
-                    <DescriptionList title="local Identifiers count:" description={twin.aspects.length}/>
+                    <DescriptionList title="Aspects count:" description={twin.aspects.length}/>
+                    <DescriptionList title="local Identifiers count:" description={twin.localIdentifiers.length}/>
                   </Link>
                 ))}
               </div> :

--- a/portal/code/tractus-x-portal/src/components/semantics/SemanticModelDetail.tsx
+++ b/portal/code/tractus-x-portal/src/components/semantics/SemanticModelDetail.tsx
@@ -16,7 +16,7 @@ import { useEffect, useState } from "react";
 import BackLink from "../navigation/backlink";
 import { Icon } from "@fluentui/react";
 import Loading from "../loading";
-import { getModelById, getModelDiagram, getDocumentationUrl, getFileUrl } from "./data";
+import { getModelById, getModelDiagram, getDocumentationUrl, getJsonSchemaUrl, getFileUrl } from "./data";
 import ErrorMessage from "../ErrorMessage";
 import DeleteModel from "./DeleteModel"
 
@@ -26,6 +26,7 @@ const SemanticModelDetail = (props) => {
   const [error, setError] = useState<any | null>(undefined);
   const [imageUrl, setImageUrl] = useState<string | null>(undefined);
   const [documentationUrl, setDocumentationUrl] = useState<string | null>(undefined);
+  const [jsonSchemaUrl, setJsonSchemaUrl] = useState<string | null>(undefined);
   const [isImageLoading, setIsImageLoading] = useState(true);
   const [fileUrl, setFileUrl] = useState<string | null>(undefined)
 
@@ -34,6 +35,7 @@ const SemanticModelDetail = (props) => {
       .then(model => setModel(model), error => setError(error.message));
     setImageUrl(getModelDiagram(id));
     setDocumentationUrl(getDocumentationUrl(id));
+    setJsonSchemaUrl(getJsonSchemaUrl(id));
     setFileUrl(getFileUrl(id));
   }, [id]);
 
@@ -61,7 +63,8 @@ const SemanticModelDetail = (props) => {
           <img src={imageUrl} className="w100pc mb30" onLoad={diagramOnLoad}></img>
           {isImageLoading && <Loading />}
         </div>
-        <a href={documentationUrl} target="_blank">See full {model.name} documentation.</a>
+        <a href={documentationUrl} target="_blank">View {model.name} documentation</a>
+        <a href={jsonSchemaUrl} target="_blank">View {model.name} Json Schema</a>
         </div> :
         <div className="h100pc df jcc">
           {error ? <ErrorMessage error={error}/> : <Loading />}

--- a/portal/code/tractus-x-portal/src/components/semantics/data.ts
+++ b/portal/code/tractus-x-portal/src/components/semantics/data.ts
@@ -76,6 +76,10 @@ export function getDocumentationUrl(id){
   return `${MODEL_URL}/${id}/documentation`;
 }
 
+export function getJsonSchemaUrl(id){
+  return `${MODEL_URL}/${id}/json-schema`;
+}
+
 export function getFileUrl(id){
   return `${MODEL_URL}/${id}/file`;
 }


### PR DESCRIPTION
Already implemented and tested in CAX-1-semantics. Cherry-picked because of potential huge conflicts.