### PR TITLE
Fix for test which fails due to different line endings on windows

### DIFF
--- a/coreservices/partsrelationshipservice/broker-proxy/src/test/java/net/catenax/brokerproxy/BrokerProxyApplicationTest.java
+++ b/coreservices/partsrelationshipservice/broker-proxy/src/test/java/net/catenax/brokerproxy/BrokerProxyApplicationTest.java
@@ -29,6 +29,6 @@ class BrokerProxyApplicationTest {
     void generatedOpenApiMatchesContract() throws Exception {
         assertThat(this.restTemplate.getForObject("http://localhost:" + port + "/broker-proxy/api-docs.yaml",
                 String.class))
-                .isEqualTo(Files.readString(new File("../api/brokerproxy-v0.1.yaml").toPath(), UTF_8), port);
+                .isEqualToNormalizingNewlines(Files.readString(new File("../api/brokerproxy-v0.1.yaml").toPath(), UTF_8));
     }
 }

--- a/coreservices/partsrelationshipservice/prs-api/src/test/java/net/catenax/prs/PrsApplicationTests.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/test/java/net/catenax/prs/PrsApplicationTests.java
@@ -36,6 +36,6 @@ class PrsApplicationTests {
     void generatedOpenApiMatchesContract() throws Exception {
         assertThat(this.restTemplate.getForObject("http://localhost:" + port + "/api/api-docs.yaml",
                 String.class))
-                .isEqualTo(Files.readString(new File("../api/prs-v0.1.yaml").toPath(), UTF_8), port);
+                .isEqualToNormalizingNewlines(Files.readString(new File("../api/prs-v0.1.yaml").toPath(), UTF_8));
     }
 }


### PR DESCRIPTION
Test (generatedOpenApiMatchesContract) which asserts existing open api generated contract with current one to validate that its up to date fails on windows as line ending are different on windows & linux platforms.