### PR TITLE
PRS dev deploment timing out

### DIFF
--- a/coreservices/partsrelationshipservice/prs-api/src/main/resources/application.yml
+++ b/coreservices/partsrelationshipservice/prs-api/src/main/resources/application.yml
@@ -19,12 +19,10 @@ spring:
       auto-offset-reset: earliest
       # Configures the Spring Kafka ErrorHandlingDeserializer that delegates to the 'real' deserializer
       value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
-      heartbeat-interval: 3000
       properties:
         # Delegate deserializers
         spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
         spring.json.trusted.packages: "*"
-        session.timeout.ms: 30000
     # Dead-Letter Topic producer
     producer:
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer


### PR DESCRIPTION
The issue was caused by a misconfiguration of the liveness probe for the PRS api. Due to the slow start the pod was killed due to the liveness probe failing for too long. This can be solved by either:
* Configuring a `initialDelayInSeconds` for the liveness probe to be executed after an (expected) initialization time
* Configuring a [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes)

This PR solved the issue using the second approach.

Successful build: https://github.com/catenax/tractusx/actions/runs/1359390847
