### PR TITLE
Fixed smoke tests

### DIFF
--- a/.github/workflows/partsrelationshipservice-deploy.yml
+++ b/.github/workflows/partsrelationshipservice-deploy.yml
@@ -193,3 +193,6 @@ jobs:
         run: |
           set -euo pipefail # safe mode
           mvn --batch-mode --update-snapshots -Dgroups=SystemTests test -Denvironment=$ENVIRONMENT
+        env:
+          PRS_EDC_PKG_USERNAME: ${{ secrets.PRS_EDC_PKG_USERNAME }}
+          PRS_EDC_PKG_PASSWORD: ${{ secrets.PRS_EDC_PKG_PASSWORD }}

--- a/.github/workflows/partsrelationshipservice-deploy.yml
+++ b/.github/workflows/partsrelationshipservice-deploy.yml
@@ -135,6 +135,9 @@ jobs:
           set -euo pipefail # safe mode
           api_url=$(jq -r .api_url.value cd/terraform-dataspace-partition/terraform-outputs.json)
           mvn --batch-mode --update-snapshots -Dgroups=SmokeTests test -DbaseURI=$api_url
+        env:
+          PRS_EDC_PKG_USERNAME: ${{ secrets.PRS_EDC_PKG_USERNAME }}
+          PRS_EDC_PKG_PASSWORD: ${{ secrets.PRS_EDC_PKG_PASSWORD }}
 
       - name: Archive production artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/partsrelationshipservice-deploy.yml
+++ b/.github/workflows/partsrelationshipservice-deploy.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           set -euo pipefail # safe mode
           api_url=$(jq -r .api_url.value cd/terraform-dataspace-partition/terraform-outputs.json)
-          mvn --batch-mode --update-snapshots -Dgroups=SmokeTests test -DbaseURI=$api_url
+          mvn --batch-mode --update-snapshots -s settings.xml -Dgroups=SmokeTests test -DbaseURI=$api_url
         env:
           PRS_EDC_PKG_USERNAME: ${{ secrets.PRS_EDC_PKG_USERNAME }}
           PRS_EDC_PKG_PASSWORD: ${{ secrets.PRS_EDC_PKG_PASSWORD }}
@@ -195,7 +195,7 @@ jobs:
       - name: "Run system tests"
         run: |
           set -euo pipefail # safe mode
-          mvn --batch-mode --update-snapshots -Dgroups=SystemTests test -Denvironment=$ENVIRONMENT
+          mvn --batch-mode --update-snapshots -s settings.xml -Dgroups=SystemTests test -Denvironment=$ENVIRONMENT
         env:
           PRS_EDC_PKG_USERNAME: ${{ secrets.PRS_EDC_PKG_USERNAME }}
           PRS_EDC_PKG_PASSWORD: ${{ secrets.PRS_EDC_PKG_PASSWORD }}


### PR DESCRIPTION
Smoke tests are failing because authentication fails when trying to download the connector dependency.
Added access token.
Successful deploy: https://github.com/catenax/tractusx/runs/4155984177?check_suite_focus=true

FYI excluding connectors dependency with the  `-pl !<dependency>` option is also a possibility to have green system tests.
I decided to add the env var for now, as we will add connector system tests soon.