### PR TITLE
Added checkstyle to connectors.

### DIFF
--- a/coreservices/partsrelationshipservice/ci/checkstyle-temporary-connector-rules.xml
+++ b/coreservices/partsrelationshipservice/ci/checkstyle-temporary-connector-rules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset name="Java Rules"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+    <description>
+        Empty temporary rulesets for connectors.
+    </description>
+</ruleset>

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ApiEndpointExtension.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ApiEndpointExtension.java
@@ -1,3 +1,12 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
 package org.eclipse.dataspaceconnector.extensions.api;
 
 import org.eclipse.dataspaceconnector.spi.protocol.web.WebService;
@@ -9,6 +18,9 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.StatusCheckerReg
 
 import java.util.Set;
 
+/**
+ * Extension providing extra consumer endpoints.
+ */
 public class ApiEndpointExtension implements ServiceExtension {
 
     @Override

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ConsumerApiController.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ConsumerApiController.java
@@ -1,3 +1,12 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
 package org.eclipse.dataspaceconnector.extensions.api;
 
 
@@ -24,6 +33,10 @@ import java.util.UUID;
 
 import static java.lang.String.format;
 
+/**
+ * Consumer API Controller.
+ * Provides consumer extra endpoints.
+ */
 @Consumes({MediaType.APPLICATION_JSON})
 @Produces({MediaType.APPLICATION_JSON})
 @Path("/")
@@ -33,12 +46,21 @@ public class ConsumerApiController {
     private final TransferProcessManager processManager;
     private final TransferProcessStore processStore;
 
+    /**
+     * @param monitor This is a logger.
+     * @param processManager Process manager responsible for sending messages to provider.
+     * @param processStore Manages storage of TransferProcess state.
+     */
     public ConsumerApiController(Monitor monitor, TransferProcessManager processManager, TransferProcessStore processStore) {
         this.monitor = monitor;
         this.processManager = processManager;
         this.processStore = processStore;
     }
 
+    /**
+     * Health endpoint.
+     * @return Consumer status
+     */
     @GET
     @Path("health")
     public String checkHealth() {
@@ -46,6 +68,13 @@ public class ConsumerApiController {
         return "I'm alive!";
     }
 
+    /**
+     * Endpoint to trigger a request, so that a file get copied into a specific destination.
+     * @param filename Path of file source.
+     * @param connectorAddress Provider connector address to send the message to.
+     * @param destinationPath Destination path where the file should be copied.
+     * @return TransferInitiateResponse with process id.
+     */
     @POST
     @Path("file/{filename}")
     public Response initiateTransfer(@PathParam("filename") String filename, @QueryParam("connectorAddress") String connectorAddress,
@@ -73,9 +102,14 @@ public class ConsumerApiController {
                 .build();
 
         var response = processManager.initiateConsumerRequest(dataRequest);
-        return response.getStatus() != ResponseStatus.OK ? Response.status(400).build() : Response.ok(response.getId()).build();
+        return response.getStatus() != ResponseStatus.OK ? Response.status(Response.Status.NOT_FOUND).build() : Response.ok(response.getId()).build();
     }
 
+    /**
+     * Provides status of a process
+     * @param requestId If of the process
+     * @return Process state
+     */
     @GET
     @Path("datarequest/{id}/state")
     public Response getStatus(@PathParam("id") String requestId) {

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileStatusChecker.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileStatusChecker.java
@@ -1,16 +1,34 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
 package org.eclipse.dataspaceconnector.extensions.api;
 
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.*;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResource;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.StatusChecker;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 
 import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
 
+/**
+ * Status checked responsible for providing a file transfer status.
+ */
 public class FileStatusChecker implements StatusChecker {
 
     private final Monitor monitor;
 
+    /**
+     * FileStatusChecker constructor
+     * @param monitor Logger
+     */
     public FileStatusChecker(Monitor monitor) {
         this.monitor = monitor;
     }

--- a/coreservices/partsrelationshipservice/connector/prs-connector-parent/pom.xml
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-parent/pom.xml
@@ -18,7 +18,7 @@
   <description>Parent Module for EDC Connectors</description>
 
   <properties>
-    <pmd.ruleset.location>../../ci/pmd-rules.xml</pmd.ruleset.location>
+    <pmd.ruleset.location>../../ci/checkstyle-temporary-connector-rules.xml</pmd.ruleset.location>
     <javaVersion>11</javaVersion>
     <rsApi>3.0.0</rsApi>
     <edcVersion>0.0.1-SNAPSHOT.Agera.1416420822</edcVersion>

--- a/coreservices/partsrelationshipservice/connector/prs-connector-parent/pom.xml
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-parent/pom.xml
@@ -18,6 +18,7 @@
   <description>Parent Module for EDC Connectors</description>
 
   <properties>
+    <pmd.ruleset.location>../../ci/pmd-rules.xml</pmd.ruleset.location>
     <javaVersion>11</javaVersion>
     <rsApi>3.0.0</rsApi>
     <edcVersion>0.0.1-SNAPSHOT.Agera.1416420822</edcVersion>

--- a/coreservices/partsrelationshipservice/connector/prs-connector-parent/pom.xml
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-parent/pom.xml
@@ -2,6 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+      <groupId>net.catenax.prs</groupId>
+      <artifactId>prs-parent</artifactId>
+      <version>${revision}</version>
+      <relativePath>../../prs-parent</relativePath>
+    </parent>
+
     <groupId>com.catenax.prs</groupId>
     <artifactId>prs-connector-parent</artifactId>
     <version>0.0.1-SNAPSHOT</version>

--- a/coreservices/partsrelationshipservice/connector/prs-connector-parent/pom.xml
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-parent/pom.xml
@@ -18,7 +18,6 @@
   <description>Parent Module for EDC Connectors</description>
 
   <properties>
-    <pmd.ruleset.location>../../ci/pmd-rules.xml</pmd.ruleset.location>
     <javaVersion>11</javaVersion>
     <rsApi>3.0.0</rsApi>
     <edcVersion>0.0.1-SNAPSHOT.Agera.1416420822</edcVersion>

--- a/coreservices/partsrelationshipservice/connector/prs-connector-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
@@ -1,3 +1,12 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
 package org.eclipse.dataspaceconnector.extensions.api;
 
 import org.eclipse.dataspaceconnector.policy.model.Action;
@@ -17,6 +26,9 @@ import java.util.Set;
 
 import static org.eclipse.dataspaceconnector.policy.model.Operator.IN;
 
+/**
+ * Extension to transfer file.
+ */
 public class FileTransferExtension implements ServiceExtension {
 
     public static final String USE_EU_POLICY = "use-eu";

--- a/coreservices/partsrelationshipservice/connector/prs-connector-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferFlowController.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferFlowController.java
@@ -1,3 +1,12 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
 package org.eclipse.dataspaceconnector.extensions.api;
 
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -13,10 +22,18 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
+/**
+ * Handles a data flow to transfer a file.
+ */
 public class FileTransferFlowController implements DataFlowController {
     private final Monitor monitor;
     private final TypeManager typeManager;
+    private static final int DELAY = 2000;
 
+    /**
+     * @param monitor Logger
+     * @param typeManager TypeManager
+     */
     public FileTransferFlowController(Monitor monitor, TypeManager typeManager) {
         this.monitor = monitor;
         this.typeManager = typeManager;
@@ -57,7 +74,7 @@ public class FileTransferFlowController implements DataFlowController {
         }
 
         try {
-            Thread.sleep(2000); // introduce delay to simulate data transfer work
+            Thread.sleep(DELAY); // introduce delay to simulate data transfer work
             Files.copy(sourcePath, destinationPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
         } catch (IOException | InterruptedException e) {
             String message = "Error copying file " + e.getMessage();

--- a/coreservices/partsrelationshipservice/prs-parent-spring-boot/pom.xml
+++ b/coreservices/partsrelationshipservice/prs-parent-spring-boot/pom.xml
@@ -26,6 +26,47 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.springdoc</groupId>
+                <artifactId>springdoc-openapi-common</artifactId>
+                <version>${springdoc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springdoc</groupId>
+                <artifactId>springdoc-openapi-ui</artifactId>
+                <version>${springdoc.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${springboot.version}</version>
+                    <configuration>
+                        <excludes>
+                            <exclude>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok</artifactId>
+                            </exclude>
+                        </excludes>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>repackage</id>
+                            <goals>
+                                <goal>repackage</goal>
+                            </goals>
+                            <configuration>
+                                <classifier>exec</classifier>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/coreservices/partsrelationshipservice/prs-parent/pom.xml
+++ b/coreservices/partsrelationshipservice/prs-parent/pom.xml
@@ -16,6 +16,7 @@
     <description>Parent module for PRS modules.</description>
 
     <properties>
+        <pmd.ruleset.location>../ci/pmd-rules.xml</pmd.ruleset.location>
         <java.version>11</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -215,7 +216,7 @@
                     <analysisCache>true</analysisCache>
                     <printFailingErrors>true</printFailingErrors>
                     <rulesets>
-                        <ruleset>../ci/pmd-rules.xml</ruleset>
+                        <ruleset>${pmd.ruleset.location}</ruleset>
                     </rulesets>
                     <excludeRoots>
                         <excludeRoot>target/generated-sources</excludeRoot>

--- a/coreservices/partsrelationshipservice/prs-parent/pom.xml
+++ b/coreservices/partsrelationshipservice/prs-parent/pom.xml
@@ -21,6 +21,8 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <pmd.ruleset.location>../ci/pmd-rules.xml</pmd.ruleset.location>
+
         <!-- Dependencies -->
         <springboot.version>2.5.4</springboot.version>
         <springdoc.version>1.5.10</springdoc.version>
@@ -45,16 +47,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.springdoc</groupId>
-                <artifactId>springdoc-openapi-common</artifactId>
-                <version>${springdoc.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springdoc</groupId>
-                <artifactId>springdoc-openapi-ui</artifactId>
-                <version>${springdoc.version}</version>
-            </dependency>
             <dependency>
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-registry-prometheus</artifactId>
@@ -118,7 +110,7 @@
                         <analysisCache>true</analysisCache>
                         <printFailingErrors>true</printFailingErrors>
                         <rulesets>
-                            <ruleset>../ci/pmd-rules.xml</ruleset>
+                            <ruleset>${pmd.ruleset.location}</ruleset>
                         </rulesets>
                     </configuration>
                     <executions>
@@ -207,30 +199,6 @@
                         </configuration>
                     </execution>
                 </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version>${springboot.version}</version>
-                    <configuration>
-                        <excludes>
-                            <exclude>
-                                <groupId>org.projectlombok</groupId>
-                                <artifactId>lombok</artifactId>
-                            </exclude>
-                        </excludes>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>repackage</id>
-                            <goals>                                                            
-                                <goal>repackage</goal>                                           
-                            </goals>              
-                            <configuration>
-                                <classifier>exec</classifier>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/coreservices/partsrelationshipservice/prs-parent/pom.xml
+++ b/coreservices/partsrelationshipservice/prs-parent/pom.xml
@@ -217,6 +217,9 @@
                     <rulesets>
                         <ruleset>../ci/pmd-rules.xml</ruleset>
                     </rulesets>
+                    <excludeRoots>
+                        <excludeRoot>target/generated-sources</excludeRoot>
+                    </excludeRoots>
                 </configuration>
                 <executions>
                     <execution>

--- a/coreservices/partsrelationshipservice/prs-parent/pom.xml
+++ b/coreservices/partsrelationshipservice/prs-parent/pom.xml
@@ -21,8 +21,6 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <pmd.ruleset.location>../ci/pmd-rules.xml</pmd.ruleset.location>
-
         <!-- Dependencies -->
         <springboot.version>2.5.4</springboot.version>
         <springdoc.version>1.5.10</springdoc.version>
@@ -74,54 +72,6 @@
                     <version>${install-plugin.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>${checkstyle-plugin.version}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>com.puppycrawl.tools</groupId>
-                            <artifactId>checkstyle</artifactId>
-                            <version>${checkstyle.version}</version>
-                        </dependency>
-                    </dependencies>
-                    <configuration>
-                        <configLocation>../ci/checkstyle.xml</configLocation>
-                        <suppressionsLocation>../ci/checkstyle-suppressions.xml</suppressionsLocation>
-                        <encoding>UTF-8</encoding>
-                        <consoleOutput>true</consoleOutput>
-                        <failsOnError>true</failsOnError>
-                        <failOnViolation>true</failOnViolation>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <phase>validate</phase>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-pmd-plugin</artifactId>
-                    <version>${pmd-plugin.version}</version>
-                    <configuration>
-                        <!-- enable incremental analysis -->
-                        <analysisCache>true</analysisCache>
-                        <printFailingErrors>true</printFailingErrors>
-                        <rulesets>
-                            <ruleset>${pmd.ruleset.location}</ruleset>
-                        </rulesets>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
                     <version>${spotbugs-plugin.version}</version>
@@ -155,51 +105,6 @@
                         </execution>
                     </executions>
                 </plugin>
-                <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>${jacoco.version}</version>
-                <configuration>
-                    <excludes>
-                        <exclude>**/*Application.class</exclude>
-                    </excludes>
-                </configuration>
-                <executions>
-                <execution>
-                    <goals>
-                        <goal>prepare-agent</goal>
-                    </goals>
-                </execution>
-                    <!-- attached to Maven test phase -->
-                    <execution>
-                        <id>report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>jacoco-check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <rule>
-                                    <element>PACKAGE</element>
-                                    <limits>
-                                        <limit>
-                                            <counter>LINE</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.8</minimum>
-                                        </limit>
-                                    </limits>
-                                </rule>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -224,6 +129,99 @@
                         <phase>clean</phase>
                         <goals>
                             <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*Application.class</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <!-- attached to Maven test phase -->
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${checkstyle-plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>${checkstyle.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <configLocation>../ci/checkstyle.xml</configLocation>
+                    <suppressionsLocation>../ci/checkstyle-suppressions.xml</suppressionsLocation>
+                    <encoding>UTF-8</encoding>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
+                    <failOnViolation>true</failOnViolation>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>${pmd-plugin.version}</version>
+                <configuration>
+                    <!-- enable incremental analysis -->
+                    <analysisCache>true</analysisCache>
+                    <printFailingErrors>true</printFailingErrors>
+                    <rulesets>
+                        <ruleset>../ci/pmd-rules.xml</ruleset>
+                    </rulesets>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/coreservices/partsrelationshipservice/prs-parent/pom.xml
+++ b/coreservices/partsrelationshipservice/prs-parent/pom.xml
@@ -164,6 +164,51 @@
                     </executions>
                 </plugin>
                 <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*Application.class</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                <execution>
+                    <goals>
+                        <goal>prepare-agent</goal>
+                    </goals>
+                </execution>
+                    <!-- attached to Maven test phase -->
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.8</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+                </plugin>
+                <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
                     <version>${springboot.version}</version>


### PR DESCRIPTION
- Added back jacoco to prs-parent.
- Added back pmd to prs-parent.
- Fixed checkstyle of consumer & provider.
- For now consumer & provider pmd points to an empty rulesets. Will make it point to the common ruleset in another PR.

I will make a second PR to make sure connectors respects the common rule set + code coverage. 
As I think it is better to merge this PR early as it adds back code coverage & checkstyle to the workflow.

