### PR TITLE
Feature/a1 mtdc 125 Deploy PRS connectors - fix pipeline race condition

### DIFF
--- a/.github/workflows/partsrelationshipservice-deploy.yml
+++ b/.github/workflows/partsrelationshipservice-deploy.yml
@@ -101,6 +101,7 @@ jobs:
   deploy_connectors:
     needs:
       - configure
+      - build_images
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Pipeline was building and deploying connectors simultaneously. Added a dependency to build the images before deploying them.

Sample deployment: https://github.com/catenax/tractusx/actions/runs/1447620386