### PR TITLE
Feature/a1 mtdc@162 edc identity

### DIFF
--- a/coreservices/partsrelationshipservice/cd/terraform-identities/README.md
+++ b/coreservices/partsrelationshipservice/cd/terraform-identities/README.md
@@ -1,0 +1,44 @@
+# Provisioning identities for the PRS Connector
+
+## About
+
+This Terraform code will provision and store an identity and credential to be used by the PRS Connector Consumer for communicating with its Key Vault. As it requires elevated privileges, it is run manually rather than in a CD pipeline. This code deploys the following:
+
+- An Azure Key Vault to securely store the generated credentials. Note that this is *not* the Key Vault to which the EDC Connector will connect, it is only meant to be accessed by the CD pipeline.
+- An X.509 Certificate (stored in Azure Key Vault).
+- An Application Registration and Service Principal used by the PRS Connector Consumer. The Certificate from Key Vault is set up to allow the principal to log in.
+  - The Client ID of the Service Principal is also stored in Azure Key Vault. Though the Client ID is not a sensitive value, is it convenient for the Connector deployment pipeline to retrieve it from the same place as its certificate.
+
+Note that the generated Certificate has a validity of one year. In a production deployment, a strategy would need to be put in place to deploy updated Certificates to existing deployments.
+
+## Provisioning
+
+You need to be logged into Azure CLI as a user with elevated Azure AD privileges, to generate and manage application registrations and service principals.
+
+Verify the default values for the backend store in `versions.tf`, and for settings in `variables.tf`.
+
+Deploy the configuration:
+
+```sh
+terraform init
+terraform apply
+```
+
+## Verify credentials
+
+You can verify the data was set up correctly as follows:
+
+```sh
+az keyvault secret download --file /tmp/cert.pfx --vault-name "$(terraform output -raw vault_name)" --name "$(terraform output -raw prs_connector_consumer_cert_name)" --encoding base64
+
+openssl pkcs12 -in /tmp/cert.pfx -passin pass: -out /tmp/cert.pem -nodes
+
+az login --service-principal --username "$(terraform output -raw prs_connector_consumer_client_id)" --password /tmp/cert.pem --tenant "$(terraform output -raw tenant_id)" --allow-no-subscriptions
+```
+
+If the last command succeeds, you have successfully authenticated with the client ID and certificate from Key Vault.
+
+```sh
+# Login again with your account
+az login
+```

--- a/coreservices/partsrelationshipservice/cd/terraform-identities/README.md
+++ b/coreservices/partsrelationshipservice/cd/terraform-identities/README.md
@@ -7,7 +7,7 @@ This Terraform code will provision and store an identity and credential to be us
 - An Azure Key Vault to securely store the generated credentials. Note that this is *not* the Key Vault to which the EDC Connector will connect, it is only meant to be accessed by the CD pipeline.
 - An X.509 Certificate (stored in Azure Key Vault).
 - An Application Registration and Service Principal used by the PRS Connector Consumer. The Certificate from Key Vault is set up to allow the principal to log in.
-  - The Client ID of the Service Principal is also stored in Azure Key Vault. Though the Client ID is not a sensitive value, is it convenient for the Connector deployment pipeline to retrieve it from the same place as its certificate.
+  - The Client ID and Object ID of the Service Principal are also stored in Azure Key Vault. Though they are not sensitive values, is it convenient for the Connector deployment pipeline to retrieve them from the same place as its certificate.
 
 Note that the generated Certificate has a validity of one year. In a production deployment, a strategy would need to be put in place to deploy updated Certificates to existing deployments.
 

--- a/coreservices/partsrelationshipservice/cd/terraform-identities/main.tf
+++ b/coreservices/partsrelationshipservice/cd/terraform-identities/main.tf
@@ -116,7 +116,15 @@ resource "azuread_service_principal" "prs-connector-consumer" {
 # in the same place as its certificate.
 resource "azurerm_key_vault_secret" "prs-connector-consumer-client-id" {
   name         = "prs-connector-consumer-client-id"
-  value        = azuread_application.prs-connector-consumer.application_id
+  value        = azuread_service_principal.prs-connector-consumer.application_id
+  key_vault_id = azurerm_key_vault.identities.id
+  depends_on = [
+    azurerm_role_assignment.current-user-secrets
+  ]
+}
+resource "azurerm_key_vault_secret" "prs-connector-consumer-object-id" {
+  name         = "prs-connector-consumer-object-id"
+  value        = azuread_service_principal.prs-connector-consumer.object_id
   key_vault_id = azurerm_key_vault.identities.id
   depends_on = [
     azurerm_role_assignment.current-user-secrets

--- a/coreservices/partsrelationshipservice/cd/terraform-identities/main.tf
+++ b/coreservices/partsrelationshipservice/cd/terraform-identities/main.tf
@@ -1,0 +1,132 @@
+# Retrieve the AAD Service Principal object for the GitHub Actions Terraform user
+data "azuread_service_principal" "terraform_cd" {
+  application_id = var.terraform_cd_principal_client_id
+}
+
+# Retrieve identity information for the current logged-in user
+data "azuread_client_config" "current" {}
+
+# Create central Key Vault for storing generated identity information and credentials
+resource "azurerm_key_vault" "identities" {
+  name                        = "${var.prefix}-${var.environment}-prs-id"
+  resource_group_name         = local.resource_group_name
+  location                    = local.location
+  enabled_for_disk_encryption = false
+  tenant_id                   = data.azuread_client_config.current.tenant_id
+  soft_delete_retention_days  = 7
+  purge_protection_enabled    = false
+
+  sku_name                  = "standard"
+  enable_rbac_authorization = true
+}
+
+# Role assignment so that the currently logged-in user may access the vault,
+# needed to add secrets and certificates
+resource "azurerm_role_assignment" "current-user-secrets" {
+  scope                = azurerm_key_vault.identities.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = data.azuread_client_config.current.object_id
+}
+resource "azurerm_role_assignment" "current-user-certificates" {
+  scope                = azurerm_key_vault.identities.id
+  role_definition_name = "Key Vault Certificates Officer"
+  principal_id         = data.azuread_client_config.current.object_id
+}
+
+# Generate a certificate to be used by the generated principal
+resource "azurerm_key_vault_certificate" "prs-connector-consumer" {
+  name         = "generated-cert"
+  key_vault_id = azurerm_key_vault.identities.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      # Server Authentication = 1.3.6.1.5.5.7.3.1
+      # Client Authentication = 1.3.6.1.5.5.7.3.2
+      extended_key_usage = ["1.3.6.1.5.5.7.3.1"]
+
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+
+      subject            = "CN=${local.resource_group_name}"
+      validity_in_months = 12
+    }
+  }
+  depends_on = [
+    azurerm_role_assignment.current-user-certificates
+  ]
+}
+
+
+# Generate an app registration to be used by the generated principal
+resource "azuread_application" "prs-connector-consumer" {
+  display_name = "CatenaX PRS Connector Consumer - ${var.environment}"
+}
+
+# Allow the app to authenticate with the generated principal
+resource "azuread_application_certificate" "prs-connector-consumer" {
+  type                  = "AsymmetricX509Cert"
+  application_object_id = azuread_application.prs-connector-consumer.id
+  value                 = azurerm_key_vault_certificate.prs-connector-consumer.certificate_data_base64
+  end_date              = azurerm_key_vault_certificate.prs-connector-consumer.certificate_attribute[0].expires
+  start_date            = azurerm_key_vault_certificate.prs-connector-consumer.certificate_attribute[0].not_before
+}
+
+# Generate a service principal
+resource "azuread_service_principal" "prs-connector-consumer" {
+  application_id               = azuread_application.prs-connector-consumer.application_id
+  app_role_assignment_required = false
+  tags = [
+    "terraform"
+  ]
+}
+
+# Store the client ID in the central Key Vault.
+# Though the Client ID is not a sensitive value, is it convenient to manage it
+# in the same place as its certificate.
+resource "azurerm_key_vault_secret" "prs-connector-consumer-client-id" {
+  name         = "prs-connector-consumer-client-id"
+  value        = azuread_application.prs-connector-consumer.application_id
+  key_vault_id = azurerm_key_vault.identities.id
+  depends_on = [
+    azurerm_role_assignment.current-user-secrets
+  ]
+}
+
+# Grant read permissions on the key vault to the GitHub Actions Terraform user.
+# Note that the "Key Vault Secrets User" role also allows downloading (exportable) certificates.
+resource "azurerm_role_assignment" "terraform-cd-secrets" {
+  scope = azurerm_key_vault.identities.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = data.azuread_service_principal.terraform_cd.object_id
+}

--- a/coreservices/partsrelationshipservice/cd/terraform-identities/main.tf
+++ b/coreservices/partsrelationshipservice/cd/terraform-identities/main.tf
@@ -123,10 +123,17 @@ resource "azurerm_key_vault_secret" "prs-connector-consumer-client-id" {
   ]
 }
 
-# Grant read permissions on the key vault to the GitHub Actions Terraform user.
+# Grant read permissions on the key vault secrets to the GitHub Actions Terraform user.
 # Note that the "Key Vault Secrets User" role also allows downloading (exportable) certificates.
 resource "azurerm_role_assignment" "terraform-cd-secrets" {
-  scope = azurerm_key_vault.identities.id
+  scope                = azurerm_key_vault.identities.id
   role_definition_name = "Key Vault Secrets User"
   principal_id         = data.azuread_service_principal.terraform_cd.object_id
+}
+
+# Grant read permissions on the key vault secrets to PRS developers.
+resource "azurerm_role_assignment" "developers-secrets" {
+  scope                = azurerm_key_vault.identities.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = var.developers_group_object_id
 }

--- a/coreservices/partsrelationshipservice/cd/terraform-identities/output.tf
+++ b/coreservices/partsrelationshipservice/cd/terraform-identities/output.tf
@@ -1,19 +1,19 @@
 output "tenant_id" {
-  value = data.azuread_client_config.current.tenant_id
+  value       = data.azuread_client_config.current.tenant_id
   description = "Azure Active Directory tenant ID."
 }
 
 output "vault_name" {
-  value = azurerm_key_vault.identities.name
+  value       = azurerm_key_vault.identities.name
   description = "Name of the Azure Key Vault storing generated credentials."
 }
 
 output "prs_connector_consumer_client_id" {
-  value = azuread_application.prs-connector-consumer.application_id
-  description = "Client ID (Application ID) of the service principal generated for the PRS Connector Consumer." 
+  value       = azuread_application.prs-connector-consumer.application_id
+  description = "Client ID (Application ID) of the service principal generated for the PRS Connector Consumer."
 }
 
 output "prs_connector_consumer_cert_name" {
-  value = azurerm_key_vault_certificate.prs-connector-consumer.name
-  description = "Name of the Certificate in Azure Key Vault for the service principal generated for the PRS Connector Consumer." 
+  value       = azurerm_key_vault_certificate.prs-connector-consumer.name
+  description = "Name of the Certificate in Azure Key Vault for the service principal generated for the PRS Connector Consumer."
 }

--- a/coreservices/partsrelationshipservice/cd/terraform-identities/output.tf
+++ b/coreservices/partsrelationshipservice/cd/terraform-identities/output.tf
@@ -1,0 +1,19 @@
+output "tenant_id" {
+  value = data.azuread_client_config.current.tenant_id
+  description = "Azure Active Directory tenant ID."
+}
+
+output "vault_name" {
+  value = azurerm_key_vault.identities.name
+  description = "Name of the Azure Key Vault storing generated credentials."
+}
+
+output "prs_connector_consumer_client_id" {
+  value = azuread_application.prs-connector-consumer.application_id
+  description = "Client ID (Application ID) of the service principal generated for the PRS Connector Consumer." 
+}
+
+output "prs_connector_consumer_cert_name" {
+  value = azurerm_key_vault_certificate.prs-connector-consumer.name
+  description = "Name of the Certificate in Azure Key Vault for the service principal generated for the PRS Connector Consumer." 
+}

--- a/coreservices/partsrelationshipservice/cd/terraform-identities/output.tf
+++ b/coreservices/partsrelationshipservice/cd/terraform-identities/output.tf
@@ -9,12 +9,12 @@ output "vault_name" {
 }
 
 output "prs_connector_consumer_client_id" {
-  value        = azuread_service_principal.prs-connector-consumer.application_id
+  value       = azuread_service_principal.prs-connector-consumer.application_id
   description = "Client ID (Application ID) of the service principal generated for the PRS Connector Consumer."
 }
 
 output "prs_connector_consumer_object_id" {
-  value        = azuread_service_principal.prs-connector-consumer.object_id
+  value       = azuread_service_principal.prs-connector-consumer.object_id
   description = "Object ID of the service principal generated for the PRS Connector Consumer."
 }
 

--- a/coreservices/partsrelationshipservice/cd/terraform-identities/output.tf
+++ b/coreservices/partsrelationshipservice/cd/terraform-identities/output.tf
@@ -9,8 +9,13 @@ output "vault_name" {
 }
 
 output "prs_connector_consumer_client_id" {
-  value       = azuread_application.prs-connector-consumer.application_id
+  value        = azuread_service_principal.prs-connector-consumer.application_id
   description = "Client ID (Application ID) of the service principal generated for the PRS Connector Consumer."
+}
+
+output "prs_connector_consumer_object_id" {
+  value        = azuread_service_principal.prs-connector-consumer.object_id
+  description = "Object ID of the service principal generated for the PRS Connector Consumer."
 }
 
 output "prs_connector_consumer_cert_name" {

--- a/coreservices/partsrelationshipservice/cd/terraform-identities/variables.tf
+++ b/coreservices/partsrelationshipservice/cd/terraform-identities/variables.tf
@@ -1,0 +1,23 @@
+variable "prefix" {
+  type        = string
+  description = "First part of name prefix used in naming resources. Use only lowercase letters and numbers."
+  default     = "cxmtpdc1"
+}
+
+variable "environment" {
+  type        = string
+  description = "Second part of name prefix used in naming resources. Use only lowercase letters and numbers."
+  default     = "dev"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group used to deploy resources."
+  default     = "catenax-terraform"
+}
+
+variable "terraform_cd_principal_client_id" {
+  type    = string
+  description = "Client ID (Application ID) of the service principal used in Terraform Deployment GitHub Action (AZURE_CREDENTIALS GitHub secret)."
+  default = "bcbeb0a5-c079-4b7b-a9d5-8e87de3958fc"
+}

--- a/coreservices/partsrelationshipservice/cd/terraform-identities/variables.tf
+++ b/coreservices/partsrelationshipservice/cd/terraform-identities/variables.tf
@@ -17,7 +17,13 @@ variable "resource_group_name" {
 }
 
 variable "terraform_cd_principal_client_id" {
-  type    = string
+  type        = string
   description = "Client ID (Application ID) of the service principal used in Terraform Deployment GitHub Action (AZURE_CREDENTIALS GitHub secret)."
-  default = "bcbeb0a5-c079-4b7b-a9d5-8e87de3958fc"
+  default     = "bcbeb0a5-c079-4b7b-a9d5-8e87de3958fc"
+}
+
+variable "developers_group_object_id" {
+  type        = string
+  description = "Object ID of the Azure AD Group for PRS developers, to be granted read access to the identities Key Vault."
+  default     = "6d96ded6-3a62-4ac6-90f9-6025282e7af9"
 }

--- a/coreservices/partsrelationshipservice/cd/terraform-identities/versions.tf
+++ b/coreservices/partsrelationshipservice/cd/terraform-identities/versions.tf
@@ -1,0 +1,46 @@
+# Configure the Azure provider
+terraform {
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "2.9.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "2.60.0"
+    }
+  }
+
+  # Persist state in a storage account
+  backend "azurerm" {
+    resource_group_name  = "catenax-terraform"
+    storage_account_name = "catenaxterraformstate"
+    container_name       = "tfstate"
+    # Key may be overriden with "terraform init -backend-config=key=${TERRAFORM_STATE_KEY}"
+    key = "prs.identities.dev.terraform.tfstate"
+  }
+
+  required_version = "~> 1.0"
+}
+
+provider "azuread" {
+  # Configuration options
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy    = true
+      recover_soft_deleted_key_vaults = true
+    }
+  }
+}
+
+data "azurerm_resource_group" "main" {
+  name = var.resource_group_name
+}
+
+locals {
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = data.azurerm_resource_group.main.location
+}


### PR DESCRIPTION
Terraform code to provision and store an identity and credential to be used by the PRS Connector Consumer for communicating with its Key Vault. As it requires elevated privileges, it is run manually rather than in a CD pipeline.

Also grants read access to secrets to the PRS Developers Azure AD group, for local development.