### PR TITLE
Feature/a1 mtdc@176 consumer API versioning

### DIFF
--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/controller/ConsumerApiController.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/controller/ConsumerApiController.java
@@ -33,9 +33,11 @@ import java.util.Optional;
  */
 @Consumes({MediaType.APPLICATION_JSON})
 @Produces({MediaType.APPLICATION_JSON})
-@Path("/")
+@Path(ConsumerApiController.API_VERSION)
 @RequiredArgsConstructor
 public class ConsumerApiController {
+
+    public static final String API_VERSION = "v0.1";
 
     /**
      * Logger.

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/controller/ConsumerApiController.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/controller/ConsumerApiController.java
@@ -37,6 +37,9 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ConsumerApiController {
 
+    /**
+     * The API version, part of the URL.
+     */
     public static final String API_VERSION = "v0.1";
 
     /**

--- a/coreservices/partsrelationshipservice/dev/connector-integration-test.sh
+++ b/coreservices/partsrelationshipservice/dev/connector-integration-test.sh
@@ -11,10 +11,10 @@ chmod +x retry
 ./wait-for-it.sh -t 60 consumer:9191
 ./wait-for-it.sh -t 60 prs:8080
 mkdir -p /tmp/copy/source /tmp/copy/dest
-requestId=$(curl -f -X POST http://consumer:9191/api/file -H "Content-type:application/json" -d '{"connectorAddress": "http://provider:8181", "destinationPath":"/tmp/copy/dest/new-document.txt", "partsTreeRequest": {
+requestId=$(curl -f -X POST http://consumer:9191/api/v0.1/file -H "Content-type:application/json" -d '{"connectorAddress": "http://provider:8181", "destinationPath":"/tmp/copy/dest/new-document.txt", "partsTreeRequest": {
                 "oneIDManufacturer": "CAXSWPFTJQEVZNZZ", "objectIDManufacturer": "UVVZI9PKX5D37RFUB", "view": "AS_BUILT", "aspect": "MATERIAL", "depth": 2}}')
-./retry -s 1 -t 120 "test \$(curl -f http://consumer:9191/api/datarequest/$requestId/state) == COMPLETED"
-curl -f http://consumer:9191/api/datarequest/$requestId/state
+./retry -s 1 -t 120 "test \$(curl -f http://consumer:9191/api/v0.1/datarequest/$requestId/state) == COMPLETED"
+curl -f http://consumer:9191/api/v0.1/datarequest/$requestId/state
 echo
 cat /tmp/copy/dest/new-document.txt
 cat /tmp/copy/dest/new-document.txt | grep "relationships\":\[\]"

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/ConnectorSystemTests.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/ConnectorSystemTests.java
@@ -82,7 +82,7 @@ public class ConnectorSystemTests {
                         .contentType("application/json")
                         .body(params)
                 .when()
-                        .post("/api/file")
+                        .post("/api/v0.1/file")
                 .then()
                         .assertThat()
                         .statusCode(HttpStatus.OK.value())


### PR DESCRIPTION
Added version string to API operations URLs, e.g. `http://consumer/api/v0.1/file`

Deployment: https://github.com/catenax/tractusx/actions/runs/1473348869