### PR TITLE
Feature/a1 mtdc@171 edc job

### DIFF
--- a/coreservices/partsrelationshipservice/Dockerfile
+++ b/coreservices/partsrelationshipservice/Dockerfile
@@ -16,6 +16,7 @@ COPY broker-proxy-integration-tests broker-proxy-integration-tests
 COPY broker-proxy broker-proxy
 COPY connector/pom.xml connector/pom.xml
 COPY connector/edc-patched-core connector/edc-patched-core
+COPY connector/edc-recursive-job connector/edc-recursive-job
 COPY connector/prs-connector-commons connector/prs-connector-commons
 COPY connector/prs-connector-consumer connector/prs-connector-consumer
 COPY connector/prs-connector-models connector/prs-connector-models

--- a/coreservices/partsrelationshipservice/ci/pmd-rules.xml
+++ b/coreservices/partsrelationshipservice/ci/pmd-rules.xml
@@ -20,6 +20,8 @@
         <exclude name="AtLeastOneConstructor"/>
         <!-- Clashes with the usage of var -->
         <exclude name="UseDiamondOperator"/>
+        <!-- Deprecated and counterproductive per PMD doc (replaced by CommentDefaultAccessModifier) -->
+        <exclude name="DefaultPackage"/>
     </rule>
     <rule ref="category/java/design.xml">
         <exclude name="LoosePackageCoupling"/>

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/README.md
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/README.md
@@ -1,11 +1,8 @@
 # edc-recursive-job
 
-The logic to orchestate multiple transfers (to build a PRS parts tree out
-of recursive calls to PRS API endpoints in multiple dataspace partitions)
-is factored out into a generic framework to manage jobs (in this module),
-that allows plugging in a custom handler to provide the logic, in our case
-to parse the output of one PRS API call to determine the next endpoints to
-call.
+The logic to orchestate multiple transfers (to build a PRS parts tree out of recursive calls to PRS API endpoints in
+multiple dataspace partitions)
+is factored out into a generic framework to manage jobs (in this module), that allows plugging in a custom handler to
+provide the logic, in our case to parse the output of one PRS API call to determine the next endpoints to call.
 
-We are in discussions with the EDC team to determine if this module
-could be integrated upstream.
+We are in discussions with the EDC team to determine if this module could be integrated upstream.

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/README.md
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/README.md
@@ -1,8 +1,5 @@
 # edc-recursive-job
 
-The logic to orchestate multiple transfers (to build a PRS parts tree out of recursive calls to PRS API endpoints in
-multiple dataspace partitions)
-is factored out into a generic framework to manage jobs (in this module), that allows plugging in a custom handler to
-provide the logic, in our case to parse the output of one PRS API call to determine the next endpoints to call.
+The logic to orchestate multiple transfers (to build a PRS parts tree out of recursive calls to PRS API endpoints in multiple dataspace partitions) is factored out into a generic framework to manage jobs (in this module), that allows plugging in a custom handler to provide the logic, in our case to parse the output of one PRS API call to determine the next endpoints to call.
 
 We are in discussions with the EDC team to determine if this module could be integrated upstream.

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/README.md
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/README.md
@@ -1,0 +1,11 @@
+# edc-recursive-job
+
+The logic to orchestate multiple transfers (to build a PRS parts tree out
+of recursive calls to PRS API endpoints in multiple dataspace partitions)
+is factored out into a generic framework to manage jobs (in this module),
+that allows plugging in a custom handler to provide the logic, in our case
+to parse the output of one PRS API call to determine the next endpoints to
+call.
+
+We are in discussions with the EDC team to determine if this module
+could be integrated upstream.

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/pom.xml
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.catenax.prs</groupId>
+        <artifactId>prs-connector-parent</artifactId>
+        <version>${revision}</version>
+        <relativePath>../prs-connector-parent</relativePath>
+    </parent>
+
+    <groupId>net.catenax.prs</groupId>
+    <artifactId>edc-recursive-job</artifactId>
+
+    <name>EDC Recursive Job Extension</name>
+    <description>EDC Extension for recursive job management</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.20</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <version>3.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- edc-patched-core needs to appear before any other edc dependency to allow overriding of EDC classes -->
+        <dependency>
+            <groupId>net.catenax.prs</groupId>
+            <artifactId>edc-patched-core</artifactId>
+            <version>${revision}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/InMemoryJobStore.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/InMemoryJobStore.java
@@ -30,15 +30,13 @@ import java.util.function.Supplier;
 public class InMemoryJobStore implements JobStore {
 
     /**
-     * Logger.
-     */
-    private final Monitor monitor;
-
-    /**
      * The timeout in milliseconds to try to acquire locks.
      */
     private static final int TIMEOUT = 30_000;
-
+    /**
+     * Logger.
+     */
+    private final Monitor monitor;
     /**
      * A lock to synchronize access to the collection of stored jobs.
      */

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/InMemoryJobStore.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/InMemoryJobStore.java
@@ -1,0 +1,166 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
+package net.catenax.prs.connector.job;
+
+import lombok.RequiredArgsConstructor;
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Manages storage of {@link MultiTransferJob} state in memory with no persistence.
+ */
+@RequiredArgsConstructor
+@SuppressWarnings("PMD.GuardLogStatement") // Monitor doesn't offer guard statements
+public class InMemoryJobStore implements JobStore {
+
+    /**
+     * Logger.
+     */
+    private final Monitor monitor;
+
+    /**
+     * The timeout in milliseconds to try to acquire locks.
+     */
+    private static final int TIMEOUT = 30_000;
+
+    /**
+     * A lock to synchronize access to the collection of stored jobs.
+     */
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    /**
+     * The collection of stored jobs.
+     */
+    @SuppressWarnings("PMD.UseConcurrentHashMap") // externally synchronized
+    private final Map<String, MultiTransferJob> jobsById = new HashMap<>();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<MultiTransferJob> find(final String jobId) {
+        return readLock(() -> Optional.ofNullable(jobsById.get(jobId)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void create(final MultiTransferJob job) {
+        writeLock(() -> {
+            job.transitionInitial();
+            jobsById.put(job.getJobId(), job);
+            return null;
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addTransferProcess(final String jobId, final String processId) {
+        modifyJob(jobId, (job) -> {
+            job.addTransferProcess(processId);
+            job.transitionInProgress();
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void completeTransferProcess(final String jobId, final String processId) {
+        modifyJob(jobId, (job) -> {
+            job.transferProcessCompleted(processId);
+            if (job.getTransferProcessIds().isEmpty()) {
+                job.transitionTransfersFinished();
+            }
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void completeJob(final String jobId) {
+        modifyJob(jobId, job -> job.transitionComplete());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void markJobInError(final String jobId, final @Nullable String errorDetail) {
+        modifyJob(jobId, job -> job.transitionError(errorDetail));
+    }
+
+    private void modifyJob(final String jobId, final Consumer<MultiTransferJob> action) {
+        writeLock(() -> {
+            final var job = jobsById.get(jobId);
+            if (job == null) {
+                monitor.warning("Job not found: " + jobId);
+            } else {
+                action.accept(job);
+            }
+            return null;
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<MultiTransferJob> findByProcessId(final String processId) {
+        return jobsById.values().stream()
+                .filter(j -> j.getTransferProcessIds().contains(processId))
+                .findFirst();
+    }
+
+    private <T> T readLock(final Supplier<T> work) {
+        try {
+            if (!lock.readLock().tryLock(TIMEOUT, TimeUnit.MILLISECONDS)) {
+                throw new EdcException("Timeout acquiring read lock");
+            }
+            try {
+                return work.get();
+            } finally {
+                lock.readLock().unlock();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new EdcException(e);
+        }
+    }
+
+    private <T> T writeLock(final Supplier<T> work) {
+        try {
+            if (!lock.writeLock().tryLock(TIMEOUT, TimeUnit.MILLISECONDS)) {
+                throw new EdcException("Timeout acquiring write lock");
+            }
+            try {
+                return work.get();
+            } finally {
+                lock.writeLock().unlock();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new EdcException(e);
+        }
+    }
+}

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobInitiateResponse.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobInitiateResponse.java
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
+package net.catenax.prs.connector.job;
+
+
+import lombok.Builder;
+import lombok.Value;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResponse;
+import org.eclipse.dataspaceconnector.spi.transfer.response.ResponseStatus;
+
+import java.util.Map;
+
+/**
+ * Represents the result of a {@link JobOrchestrator#startJob(Map)} operation.
+ * <p>
+ * This class is modeled after the {@link TransferInitiateResponse} class.
+ */
+@Value
+@Builder
+public class JobInitiateResponse {
+    /**
+     * Job identifier.
+     */
+    private final String jobId;
+
+    /**
+     * Optional error message.
+     */
+    private final String error;
+
+    /**
+     * Response status.
+     */
+    private final ResponseStatus status;
+}

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobOrchestrator.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobOrchestrator.java
@@ -1,0 +1,198 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
+package net.catenax.prs.connector.job;
+
+import lombok.Builder;
+import lombok.Value;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResponse;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessObservable;
+import org.eclipse.dataspaceconnector.spi.transfer.response.ResponseStatus;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.UUID.randomUUID;
+
+/**
+ * Orchestrator service for recursive {@link MultiTransferJob}s that potentially
+ * comprise multiple transfers.
+ */
+@SuppressWarnings({
+        "PMD.GuardLogStatement", // Monitor doesn't offer guard statements
+        "PMD.AvoidCatchingGenericException"}) // Handle RuntimeException from callbacks
+public class JobOrchestrator {
+
+    /**
+     * Transfer process manager.
+     */
+    private final TransferProcessManager processManager;
+
+    /**
+     * Job store.
+     */
+    private final JobStore jobStore;
+
+    /**
+     * Job handler containing the logic to start transfers and process
+     * transfer results.
+     */
+    private final RecursiveJobHandler handler;
+
+    /**
+     * Logger.
+     */
+    private final Monitor monitor;
+
+    /**
+     * Create a new instance of {@link JobOrchestrator}.
+     *
+     * @param processManager            Process manager.
+     * @param jobStore                  Job store.
+     * @param handler                   Recursive job handler.
+     * @param transferProcessObservable Transfer process observable.
+     * @param monitor                   Logger.
+     */
+    public JobOrchestrator(
+            final TransferProcessManager processManager,
+            final JobStore jobStore,
+            final RecursiveJobHandler handler,
+            final TransferProcessObservable transferProcessObservable,
+            final Monitor monitor) {
+        this.processManager = processManager;
+        this.jobStore = jobStore;
+        this.handler = handler;
+        this.monitor = monitor;
+
+        transferProcessObservable.registerListener(new JobTransferCallback(this));
+    }
+
+    /**
+     * Start a job.
+     *
+     * @param jobData additional data for the job to managed by the {@link JobStore}.
+     * @return response.
+     */
+    public JobInitiateResponse startJob(final Map<String, String> jobData) {
+        final var job = MultiTransferJob.builder()
+                .jobId(randomUUID().toString())
+                .jobData(jobData)
+                .state(JobState.UNSAVED)
+                .build();
+
+        jobStore.create(job);
+
+        final Stream<DataRequest> requests;
+        try {
+            requests = handler.initiate(job);
+        } catch (RuntimeException e) {
+            markJobInError(job, e, "Handler method failed");
+            return JobInitiateResponse.builder().jobId(job.getJobId()).status(ResponseStatus.FATAL_ERROR).build();
+        }
+
+        long transferCount;
+        try {
+            transferCount = startTransfers(job, requests);
+        } catch (JobException e) {
+            return JobInitiateResponse.builder().jobId(job.getJobId()).status(e.getStatus()).build();
+        }
+
+        // If no transfers are requested, job is already complete
+        if (transferCount == 0) {
+            jobStore.completeJob(job.getJobId());
+        }
+
+        return JobInitiateResponse.builder().jobId(job.getJobId()).status(ResponseStatus.OK).build();
+    }
+
+    /**
+     * Callback invoked when a transfer has completed.
+     *
+     * @param process
+     */
+    /* package */ void transferProcessCompleted(final TransferProcess process) {
+        final var jobEntry = jobStore.findByProcessId(process.getId());
+        if (!jobEntry.isPresent()) {
+            monitor.severe("Job not found for transfer " + process.getId());
+            return;
+        }
+        final var job = jobEntry.get();
+
+        if (job.getState() != JobState.IN_PROGRESS) {
+            monitor.info("Ignoring transfer complete event for job " + job.getJobId() + " in state " + job.getState());
+            return;
+        }
+
+        final Stream<DataRequest> requests;
+        try {
+            requests = handler.recurse(job, process);
+        } catch (RuntimeException e) {
+            markJobInError(job, e, "Handler method failed");
+            return;
+        }
+
+        try {
+            startTransfers(job, requests);
+        } catch (JobException e) {
+            markJobInError(job, e, "Failed to start a transfer");
+            return;
+        }
+
+        jobStore.completeTransferProcess(job.getJobId(), process.getId());
+
+        if (job.getState() == JobState.TRANSFERS_FINISHED) {
+            try {
+                handler.complete(job);
+            } catch (RuntimeException e) {
+                markJobInError(job, e, "Handler method failed");
+                return;
+            }
+            jobStore.completeJob(job.getJobId());
+        }
+    }
+
+    private void markJobInError(final MultiTransferJob job, final Throwable exception, final String message) {
+        monitor.severe(message, exception);
+        jobStore.markJobInError(job.getJobId(), message);
+    }
+
+    private long startTransfers(final MultiTransferJob job, final Stream<DataRequest> dataRequests) /* throws JobException */ {
+        return dataRequests
+                .map(r -> startTransfer(job, r))
+                .collect(Collectors.counting());
+    }
+
+    private TransferInitiateResponse startTransfer(final MultiTransferJob job, final DataRequest dataRequest)  /* throws JobException */ {
+        final var response = processManager.initiateConsumerRequest(dataRequest);
+
+        if (response.getStatus() != ResponseStatus.OK) {
+            throw JobException.builder().status(response.getStatus()).build();
+        }
+
+        jobStore.addTransferProcess(job.getJobId(), response.getId());
+        return response;
+    }
+
+    /**
+     * Exception used to stop creating additional transfers if one transfer creation fails.
+     */
+    @Value
+    @Builder
+    private static class JobException extends RuntimeException {
+        /**
+         * The status of the transfer in error.
+         */
+        private final ResponseStatus status;
+    }
+}

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobOrchestrator.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobOrchestrator.java
@@ -30,8 +30,8 @@ import static java.util.UUID.randomUUID;
  * comprise multiple transfers.
  */
 @SuppressWarnings({
-        "PMD.GuardLogStatement", // Monitor doesn't offer guard statements
-        "PMD.AvoidCatchingGenericException"}) // Handle RuntimeException from callbacks
+    "PMD.GuardLogStatement", // Monitor doesn't offer guard statements
+    "PMD.AvoidCatchingGenericException"}) // Handle RuntimeException from callbacks
 public class JobOrchestrator {
 
     /**

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobState.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobState.java
@@ -1,0 +1,30 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
+package net.catenax.prs.connector.job;
+
+
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
+
+import java.util.Map;
+
+
+/**
+ * Represents the state of a {@link MultiTransferJob}.
+ * <p>
+ * This class is inspired by the {@link TransferProcessStates} class.
+ */
+public enum JobState {
+    UNSAVED,
+    INITIAL,
+    IN_PROGRESS,
+    TRANSFERS_FINISHED,
+    COMPLETED,
+    ERROR;
+}

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobState.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobState.java
@@ -12,8 +12,6 @@ package net.catenax.prs.connector.job;
 
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 
-import java.util.Map;
-
 
 /**
  * Represents the state of a {@link MultiTransferJob}.

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobStore.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobStore.java
@@ -1,0 +1,78 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
+package net.catenax.prs.connector.job;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+/**
+ * Manages storage of {@link MultiTransferJob} state.
+ */
+public interface JobStore {
+    /**
+     * Retrieve a job by its identifier.
+     *
+     * @param jobId the identifier of the job to retrieve.
+     * @return the job if found, otherwise empty.
+     * @see MultiTransferJob#getJobId()
+     */
+    Optional<MultiTransferJob> find(String jobId);
+
+    /**
+     * Retrieve a job by its identifier. Only retrieves jobs
+     * for which the transfer has not been completed
+     * with {@link #completeTransferProcess(String, String)}.
+     *
+     * @param processId the transfer process identifier.
+     * @return the job if found, otherwise empty.
+     */
+    Optional<MultiTransferJob> findByProcessId(String processId);
+
+    /**
+     * Create a job.
+     *
+     * @param job the job to create and manage.
+     */
+    void create(MultiTransferJob job);
+
+    /**
+     * Add a transfer process identifier to a job.
+     *
+     * @param jobId     the job identifier.
+     * @param processId identifier of the transfer process to attach.
+     */
+    void addTransferProcess(String jobId, String processId);
+
+    /**
+     * Mark transfer process completed for the job.
+     *
+     * @param jobId     the job identifier.
+     * @param processId identifier of the transfer process to mark completed.
+     */
+    void completeTransferProcess(String jobId, String processId);
+
+    /**
+     * Mark job as completed.
+     *
+     * @param jobId the job identifier.
+     * @see JobState#COMPLETED
+     */
+    void completeJob(String jobId);
+
+    /**
+     * Mark job as in error.
+     *
+     * @param jobId       the job identifier.
+     * @param errorDetail an optional error message.
+     * @see JobState#ERROR
+     */
+    void markJobInError(String jobId, @Nullable String errorDetail);
+}

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobTransferCallback.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobTransferCallback.java
@@ -1,0 +1,38 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
+package net.catenax.prs.connector.job;
+
+
+import lombok.RequiredArgsConstructor;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessListener;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+
+/**
+ * {@TransferProcessObservable} callback invoked when a transfer has completed.
+ * Used by the {@JobOrchestrator} to be notified of transfer completions.
+ */
+@RequiredArgsConstructor
+class JobTransferCallback implements TransferProcessListener {
+
+    /**
+     * Job orchestrator.
+     */
+    private final JobOrchestrator jobOrchestrator;
+
+    /**
+     * Callback invoked by the EDC framework when a transfer has completed.
+     *
+     * @param process
+     */
+    @Override
+    public void completed(final TransferProcess process) {
+        jobOrchestrator.transferProcessCompleted(process);
+    }
+}

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/MultiTransferJob.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/MultiTransferJob.java
@@ -1,0 +1,131 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
+package net.catenax.prs.connector.job;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static java.lang.String.format;
+
+/**
+ * Entity for recursive jobs that potentially comprise multiple transfers.
+ */
+@ToString
+public class MultiTransferJob {
+
+    /**
+     * Job identifier.
+     */
+    @Getter
+    private final String jobId;
+    /**
+     * Collection of transfer IDs that have not yet completed for the job.
+     */
+    private final Set<String> transferProcessIds = new LinkedHashSet<>();
+    /**
+     * Job state.
+     */
+    @Getter
+    private JobState state;
+    /**
+     * Arbitrary data attached to the job.
+     */
+    @Getter
+    private Map<String, String> jobData;
+    /**
+     * Error detail, potentially set if {@link #getState() state} is {@link JobState#ERROR}.
+     */
+    @Getter
+    private String errorDetail;
+
+    /**
+     * Create a new instance of {@link MultiTransferJob}.
+     *
+     * @param jobId   Job identifier
+     * @param state   Job state
+     * @param jobData Arbitrary data attached to the job
+     */
+    @Builder(toBuilder = true)
+    public MultiTransferJob(
+            final String jobId,
+            final JobState state,
+            final Map<String, String> jobData) {
+        this.jobId = jobId;
+        this.state = state;
+        this.jobData = jobData == null ? Map.of() : Map.copyOf(jobData); // immutable
+    }
+
+    /**
+     * Transition the job to the {@link JobState#INITIAL} state.
+     */
+    /* package */ void transitionInitial() {
+        transition(JobState.INITIAL, JobState.UNSAVED);
+    }
+
+    /**
+     * Transition the job to the {@link JobState#IN_PROGRESS} state.
+     */
+    /* package */ void transitionInProgress() {
+        transition(JobState.IN_PROGRESS, JobState.INITIAL, JobState.IN_PROGRESS);
+    }
+
+    /**
+     * Transition the job to the {@link JobState#TRANSFERS_FINISHED} state.
+     */
+    /* package */ void transitionTransfersFinished() {
+        transition(JobState.TRANSFERS_FINISHED, JobState.IN_PROGRESS);
+    }
+
+    /**
+     * Transition the job to the {@link JobState#COMPLETED} state.
+     */
+    /* package */ void transitionComplete() {
+        transition(JobState.COMPLETED, JobState.TRANSFERS_FINISHED, JobState.INITIAL);
+    }
+
+    /**
+     * Transition the job to the {@link JobState#ERROR} state.
+     */
+    /* package */ void transitionError(final @Nullable String errorDetail) {
+        state = JobState.ERROR;
+        this.errorDetail = errorDetail;
+    }
+
+    /**
+     * Transition the job to the {@link JobState#INITIAL} state.
+     */
+    /* package */ void addTransferProcess(final String transferProcessId) {
+        transferProcessIds.add(transferProcessId);
+    }
+
+    /* package */ void transferProcessCompleted(final String jobId) {
+        transferProcessIds.remove(jobId);
+    }
+
+    private void transition(final JobState end, final JobState... starts) {
+        if (Arrays.stream(starts).noneMatch(s -> s == state)) {
+            throw new IllegalStateException(format("Cannot transition from state %s to %s", state, end));
+        }
+        state = end;
+    }
+
+    /* package */ Collection<String> getTransferProcessIds() {
+        return Collections.unmodifiableSet(this.transferProcessIds);
+    }
+}

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/RecursiveJobHandler.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/RecursiveJobHandler.java
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
+package net.catenax.prs.connector.job;
+
+
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+
+import java.util.stream.Stream;
+
+/**
+ * Interface for extensions to provide the logic to build jobs with
+ * custom logic to run multiple transfers.
+ */
+public interface RecursiveJobHandler {
+    /**
+     * Start the recursive process by creating any number of transfers.
+     *
+     * @param job job definition.
+     * @return a stream of {@DataRequest}. One data transfer will be initiated for each item.
+     */
+    Stream<DataRequest> initiate(MultiTransferJob job);
+
+    /**
+     * Continue the recursive process by creating any number of transfers from
+     * the result of a completed transfer.
+     *
+     * @param job             job definition.
+     * @param transferProcess completed transfer.
+     * @return a stream of {@DataRequest}. One data transfer will be initiated for each item.
+     */
+    Stream<DataRequest> recurse(MultiTransferJob job, TransferProcess transferProcess);
+
+    /**
+     * Called when all transfers in the job have completed.
+     *
+     * @param job job definition.
+     */
+    void complete(MultiTransferJob job);
+}

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/test/java/net/catenax/prs/connector/job/InMemoryJobStoreTest.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/test/java/net/catenax/prs/connector/job/InMemoryJobStoreTest.java
@@ -1,0 +1,227 @@
+package net.catenax.prs.connector.job;
+
+import com.github.javafaker.Faker;
+import org.eclipse.dataspaceconnector.monitor.ConsoleMonitor;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class InMemoryJobStoreTest {
+
+    Monitor monitor = new ConsoleMonitor();
+    InMemoryJobStore sut = new InMemoryJobStore(monitor);
+    Faker faker = new Faker();
+    TestMother generate = new TestMother();
+    MultiTransferJob job = generate.job(JobState.UNSAVED);
+    MultiTransferJob job2 = generate.job(JobState.UNSAVED);
+    MultiTransferJob originalJob = job.toBuilder().build();
+    String otherJobId = faker.lorem().characters();
+    String processId = faker.lorem().characters();
+    String processId2 = faker.lorem().characters();
+    String errorDetail = faker.lorem().sentence();
+
+    @Test
+    void find_WhenNotFound() {
+        assertThat(sut.find(otherJobId)).isEmpty();
+    }
+
+    @Test
+    void findByProcessId_WhenFound() {
+        sut.create(job);
+        sut.addTransferProcess(job.getJobId(), processId);
+        sut.create(job2);
+        sut.addTransferProcess(job2.getJobId(), processId2);
+
+        assertThat(sut.findByProcessId(processId)).contains(job);
+    }
+
+    @Test
+    void findByProcessId_WhenNotFound() {
+        sut.create(job);
+        sut.addTransferProcess(job.getJobId(), processId);
+
+        assertThat(sut.findByProcessId(processId2)).isEmpty();
+    }
+
+    @Test
+    void create_and_find() {
+        sut.create(job);
+        assertThat(sut.find(job.getJobId())).isPresent()
+                .get()
+                .usingRecursiveComparison()
+                .isEqualTo(originalJob.toBuilder().state(JobState.INITIAL).build());
+        assertThat(sut.find(otherJobId)).isEmpty();
+    }
+
+    @Test
+    void addTransferProcess() {
+        sut.create(job);
+        sut.addTransferProcess(job.getJobId(), processId);
+        assertThat(job.getTransferProcessIds()).containsExactly(processId);
+    }
+
+    @Test
+    void completeTransferProcess_WhenJobNotFound() {
+        sut.completeTransferProcess(otherJobId, processId);
+    }
+
+    @Test
+    void completeTransferProcess_WhenTransferFound() {
+        // Arrange
+        sut.create(job);
+        sut.addTransferProcess(job.getJobId(), processId);
+
+        // Act
+        sut.completeTransferProcess(job.getJobId(), processId);
+
+        // Assert
+        assertThat(job.getTransferProcessIds()).isEmpty();
+    }
+
+    @Test
+    void completeTransferProcess_WhenTransferNotFound() {
+        // Act
+        sut.completeTransferProcess(job.getJobId(), processId);
+
+        // Assert
+        assertThat(job.getTransferProcessIds()).isEmpty();
+    }
+
+    @Test
+    void completeTransferProcess_WhenTransferAlreadyCompleted() {
+        // Arrange
+        sut.create(job);
+        sut.addTransferProcess(job.getJobId(), processId);
+        sut.completeTransferProcess(job.getJobId(), processId);
+
+        // Act
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> sut.completeTransferProcess(job.getJobId(), processId));
+
+        // Assert
+        assertThat(job.getTransferProcessIds()).isEmpty();
+    }
+
+    @Test
+    void completeTransferProcess_WhenNotLastTransfer_DoesNotTransitionJob() {
+        // Arrange
+        sut.create(job);
+        sut.addTransferProcess(job.getJobId(), processId);
+        sut.addTransferProcess(job.getJobId(), processId2);
+
+        // Act
+        sut.completeTransferProcess(job.getJobId(), processId);
+
+        // Assert
+        assertThat(job.getState()).isEqualTo(JobState.IN_PROGRESS);
+    }
+
+    @Test
+    void completeTransferProcess_WhenLastTransfer_TransitionsJob() {
+        // Arrange
+        sut.create(job);
+        sut.addTransferProcess(job.getJobId(), processId);
+        sut.addTransferProcess(job.getJobId(), processId2);
+
+        // Act
+        sut.completeTransferProcess(job.getJobId(), processId);
+        sut.completeTransferProcess(job.getJobId(), processId2);
+
+        // Assert
+        assertThat(job.getState()).isEqualTo(JobState.TRANSFERS_FINISHED);
+    }
+
+    @Test
+    void completeJob_WhenJobNotFound() {
+        // Arrange
+        sut.create(job);
+        // Act
+        sut.completeJob(otherJobId);
+        // Assert
+        assertThat(job.getState()).isEqualTo(JobState.INITIAL);
+    }
+
+    @Test
+    void completeJob_WhenJobInInitialState() {
+        // Arrange
+        sut.create(job);
+        sut.create(job2);
+        // Act
+        sut.completeJob(job.getJobId());
+        // Assert
+        assertThat(job.getState()).isEqualTo(JobState.COMPLETED);
+        assertThat(job2.getState()).isEqualTo(JobState.INITIAL);
+    }
+
+    @Test
+    void completeJob_WhenJobInTransfersCompletedState() {
+        // Arrange
+        sut.create(job);
+        sut.addTransferProcess(job.getJobId(), processId);
+        sut.completeTransferProcess(job.getJobId(), processId);
+        // Act
+        sut.completeJob(job.getJobId());
+        // Assert
+        assertThat(job.getState()).isEqualTo(JobState.COMPLETED);
+    }
+
+    @Test
+    void completeJob_WhenJobInTransfersInProgressState() {
+        // Arrange
+        sut.create(job);
+        sut.addTransferProcess(job.getJobId(), processId);
+        // Act
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> sut.completeJob(job.getJobId()));
+        // Assert
+        assertThat(job.getState()).isEqualTo(JobState.IN_PROGRESS);
+    }
+
+    @Test
+    void markJobInError_WhenJobNotFound() {
+        // Arrange
+        sut.create(job);
+        // Act
+        sut.markJobInError(otherJobId, errorDetail);
+        // Assert
+        assertThat(job.getState()).isEqualTo(JobState.INITIAL);
+    }
+
+    @Test
+    void markJobInError_WhenJobInInitialState() {
+        // Arrange
+        sut.create(job);
+        sut.create(job2);
+        // Act
+        sut.markJobInError(job.getJobId(), errorDetail);
+        // Assert
+        assertThat(job.getState()).isEqualTo(JobState.ERROR);
+        assertThat(job2.getState()).isEqualTo(JobState.INITIAL);
+        assertThat(job.getErrorDetail()).isEqualTo(errorDetail);
+    }
+
+    @Test
+    void markJobInError_WhenJobInTransfersCompletedState() {
+        // Arrange
+        sut.create(job);
+        sut.addTransferProcess(job.getJobId(), processId);
+        sut.completeTransferProcess(job.getJobId(), processId);
+        // Act
+        sut.markJobInError(job.getJobId(), errorDetail);
+        // Assert
+        assertThat(job.getState()).isEqualTo(JobState.ERROR);
+    }
+
+    @Test
+    void markJobInError_WhenJobInTransfersInProgressState() {
+        // Arrange
+        sut.create(job);
+        sut.addTransferProcess(job.getJobId(), processId);
+        // Act
+        sut.markJobInError(job.getJobId(), errorDetail);
+        // Assert
+        assertThat(job.getState()).isEqualTo(JobState.ERROR);
+    }
+}

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/test/java/net/catenax/prs/connector/job/JobOrchestratorTest.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/test/java/net/catenax/prs/connector/job/JobOrchestratorTest.java
@@ -117,6 +117,7 @@ class JobOrchestratorTest {
         // Arrange
         when(handler.initiate(any(MultiTransferJob.class)))
                 .thenReturn(Stream.empty());
+
         // Act
         var response = sut.startJob(job.getJobData());
         var newJob = getStartedJob();
@@ -141,9 +142,9 @@ class JobOrchestratorTest {
 
         // Act
         var response = sut.startJob(job.getJobData());
-        // Act
-        var newJob = getStartedJob();
 
+        // Assert
+        var newJob = getStartedJob();
         assertThat(response)
                 .isEqualTo(
                         JobInitiateResponse.builder().jobId(newJob.getJobId()).status(ResponseStatus.OK).build());
@@ -180,6 +181,7 @@ class JobOrchestratorTest {
         // Arrange
         when(handler.initiate(any(MultiTransferJob.class)))
                 .thenThrow(new RuntimeException());
+
         // Act
         var response = sut.startJob(job.getJobData());
 
@@ -228,7 +230,7 @@ class JobOrchestratorTest {
         // Act
         callCompleteAndReturnNextTransfers(Stream.empty());
 
-        // Act
+        // Assert
         verify(jobStore).completeTransferProcess(job.getJobId(), transfer.getId());
         verifyNoMoreInteractions(jobStore);
         verifyNoMoreInteractions(handler);
@@ -243,7 +245,7 @@ class JobOrchestratorTest {
         // Act
         callCompleteAndReturnNextTransfers(Stream.empty());
 
-        // Act
+        // Assert
         verify(handler).complete(job);
         verify(jobStore).completeJob(job.getJobId());
     }
@@ -262,7 +264,7 @@ class JobOrchestratorTest {
         // Act
         callCompleteAndReturnNextTransfers(Stream.empty());
 
-        // Act
+        // Assert
         verify(jobStore).markJobInError(job.getJobId(), "Handler method failed");
         verifyNoMoreInteractions(jobStore);
         verifyNoInteractions(processManager);
@@ -277,7 +279,7 @@ class JobOrchestratorTest {
         // Act
         callTransferProcessCompletedViaCallback();
 
-        // Act
+        // Assert
         verify(monitor).severe("Job not found for transfer " + transfer.getId());
         verifyNoInteractions(handler);
         verifyNoMoreInteractions(jobStore);
@@ -294,7 +296,7 @@ class JobOrchestratorTest {
                 .thenReturn(Optional.of(job));
         callTransferProcessCompletedViaCallback();
 
-        // Act
+        // Assert
         verifyNoMoreInteractions(jobStore);
         verifyNoInteractions(handler);
     }

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/test/java/net/catenax/prs/connector/job/JobOrchestratorTest.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/test/java/net/catenax/prs/connector/job/JobOrchestratorTest.java
@@ -1,0 +1,365 @@
+package net.catenax.prs.connector.job;
+
+import org.eclipse.dataspaceconnector.monitor.ConsoleMonitor;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResponse;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessObservable;
+import org.eclipse.dataspaceconnector.spi.transfer.response.ResponseStatus;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JobOrchestratorTest {
+
+    @Spy
+    Monitor monitor = new ConsoleMonitor();
+    @Mock
+    TransferProcessManager processManager;
+    @Mock
+    JobStore jobStore;
+    @Mock
+    RecursiveJobHandler handler;
+    @Mock
+    TransferProcessObservable transferProcessObservable;
+    @InjectMocks
+    JobOrchestrator sut;
+
+    @Captor
+    ArgumentCaptor<MultiTransferJob> jobCaptor;
+    @Captor
+    ArgumentCaptor<JobTransferCallback> callbackCaptor;
+
+    Pattern uuid = Pattern.compile("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+
+    TestMother generate = new TestMother();
+    MultiTransferJob job = generate.job(JobState.IN_PROGRESS);
+    DataRequest dataRequest = generate.dataRequest();
+    DataRequest dataRequest2 = generate.dataRequest();
+    TransferInitiateResponse okResponse = generate.okResponse();
+    TransferInitiateResponse okResponse2 = generate.okResponse();
+    TransferProcess transfer = generate.transfer();
+
+    @Test
+    void startJob_storesJobWithDataAndState() {
+        assertThat(startJob())
+                .usingRecursiveComparison()
+                .ignoringFields("jobId")
+                .isEqualTo(MultiTransferJob.builder()
+                        .jobData(job.getJobData())
+                        .state(JobState.UNSAVED)
+                        .build());
+    }
+
+    @Test
+    void startJob_storesJobWithUuidAsIdentifier() {
+        assertThat(startJob().getJobId())
+                .matches(uuid);
+    }
+
+    @Test
+    void startJob_callsHandlerWithJob() {
+        // Act
+        var newJob = startJob();
+
+        // Assert
+        verify(handler).initiate(jobCaptor.capture());
+        MultiTransferJob job1 = jobCaptor.getValue();
+        assertThat(job1).isEqualTo(newJob);
+    }
+
+    @Test
+    void startJob_WithTwoDataRequests_StartsTransfers() {
+        // Arrange
+        when(handler.initiate(any(MultiTransferJob.class)))
+                .thenReturn(Stream.of(dataRequest, dataRequest2));
+        when(processManager.initiateConsumerRequest(dataRequest))
+                .thenReturn(okResponse);
+        when(processManager.initiateConsumerRequest(dataRequest2))
+                .thenReturn(okResponse2);
+
+        // Act
+        var newJob = startJob();
+
+        // Assert
+        verify(processManager).initiateConsumerRequest(dataRequest);
+        verify(jobStore).addTransferProcess(newJob.getJobId(), okResponse.getId());
+        verify(processManager).initiateConsumerRequest(dataRequest2);
+        verify(jobStore).addTransferProcess(newJob.getJobId(), okResponse2.getId());
+    }
+
+    @Test
+    void startJob_WithZeroDataRequest_CompletesJob() {
+        // Arrange
+        when(handler.initiate(any(MultiTransferJob.class)))
+                .thenReturn(Stream.empty());
+        // Act
+        var response = sut.startJob(job.getJobData());
+        var newJob = getStartedJob();
+
+        // Assert
+        verifyNoInteractions(processManager);
+        verify(jobStore).completeJob(newJob.getJobId());
+        verifyNoMoreInteractions(jobStore);
+
+        assertThat(response)
+                .isEqualTo(
+                        JobInitiateResponse.builder().jobId(newJob.getJobId()).status(ResponseStatus.OK).build());
+    }
+
+    @Test
+    void startJob_WithSuccessfulTransferStarts_ReturnsOk() {
+        // Arrange
+        when(handler.initiate(any(MultiTransferJob.class)))
+                .thenReturn(Stream.of(dataRequest));
+        when(processManager.initiateConsumerRequest(dataRequest))
+                .thenReturn(okResponse);
+
+        // Act
+        var response = sut.startJob(job.getJobData());
+        // Act
+        var newJob = getStartedJob();
+
+        assertThat(response)
+                .isEqualTo(
+                        JobInitiateResponse.builder().jobId(newJob.getJobId()).status(ResponseStatus.OK).build());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ResponseStatus.class, names = "OK", mode = EXCLUDE)
+    void startJob_WhenTransferStartUnsuccessful_Abort(ResponseStatus status) {
+        // Arrange
+        when(handler.initiate(any(MultiTransferJob.class)))
+                .thenReturn(Stream.of(dataRequest, dataRequest2));
+        when(processManager.initiateConsumerRequest(dataRequest))
+                .thenReturn(generate.response(status));
+
+        // Act
+        var response = sut.startJob(job.getJobData());
+
+        // Assert
+        verify(processManager).initiateConsumerRequest(dataRequest);
+        verify(processManager, never()).initiateConsumerRequest(dataRequest2);
+
+        // temporarily created job should be deleted
+        verify(jobStore).create(jobCaptor.capture());
+        verifyNoMoreInteractions(jobStore);
+
+        assertThat(response)
+                .isEqualTo(
+                        JobInitiateResponse.builder().jobId(jobCaptor.getValue().getJobId()).status(status).build());
+    }
+
+
+    @Test
+    void startJob_WhenHandlerInitiateThrows_StopJob() {
+        // Arrange
+        when(handler.initiate(any(MultiTransferJob.class)))
+                .thenThrow(new RuntimeException());
+        // Act
+        var response = sut.startJob(job.getJobData());
+
+        // Assert
+        verify(jobStore).create(jobCaptor.capture());
+        verify(jobStore).markJobInError(jobCaptor.getValue().getJobId(), "Handler method failed");
+        verifyNoMoreInteractions(jobStore);
+        verifyNoInteractions(processManager);
+
+        assertThat(response)
+                .isEqualTo(
+                        JobInitiateResponse.builder().jobId(jobCaptor.getValue().getJobId()).status(ResponseStatus.FATAL_ERROR).build());
+    }
+
+    @Test
+    void transferProcessCompleted_WhenCalledBackForCompletedTransfer_RunsNextTransfers() {
+        // Arrange
+        when(processManager.initiateConsumerRequest(dataRequest))
+                .thenReturn(okResponse);
+        when(processManager.initiateConsumerRequest(dataRequest2))
+                .thenReturn(okResponse2);
+
+        // Act
+        callCompleteAndReturnNextTransfers(Stream.of(dataRequest, dataRequest2));
+
+        // Assert
+        verify(processManager).initiateConsumerRequest(dataRequest);
+        verify(jobStore).addTransferProcess(job.getJobId(), okResponse.getId());
+        verify(jobStore).addTransferProcess(job.getJobId(), okResponse2.getId());
+        verify(jobStore).completeTransferProcess(job.getJobId(), transfer.getId());
+    }
+
+    @Test
+    void transferProcessCompleted_WhenCalledBackForCompletedTransfer_WithoutNextTransfer() {
+        // Act
+        callCompleteAndReturnNextTransfers(Stream.empty());
+
+        // Assert
+        verify(jobStore).completeTransferProcess(job.getJobId(), transfer.getId());
+        verifyNoInteractions(processManager);
+        verifyNoMoreInteractions(jobStore);
+    }
+
+    @Test
+    void transferProcessCompleted_WhenJobNotCompleted_DoesNotCallComplete() {
+        // Act
+        callCompleteAndReturnNextTransfers(Stream.empty());
+
+        // Act
+        verify(jobStore).completeTransferProcess(job.getJobId(), transfer.getId());
+        verifyNoMoreInteractions(jobStore);
+        verifyNoMoreInteractions(handler);
+    }
+
+    @Test
+    void transferProcessCompleted_WhenJobCompleted_CallsComplete() {
+        // Arrange
+        doAnswer(i -> byCompletingJob())
+                .when(jobStore).completeTransferProcess(job.getJobId(), transfer.getId());
+
+        // Act
+        callCompleteAndReturnNextTransfers(Stream.empty());
+
+        // Act
+        verify(handler).complete(job);
+        verify(jobStore).completeJob(job.getJobId());
+    }
+
+
+    @Test
+    void transferProcessCompleted_WhenHandlerCompleteThrows_StopJob() {
+        // Arrange
+        doAnswer(i -> byCompletingJob())
+                .when(jobStore).completeTransferProcess(job.getJobId(), transfer.getId());
+        doAnswer(i -> {
+            throw new RuntimeException();
+        })
+                .when(handler).complete(any());
+
+        // Act
+        callCompleteAndReturnNextTransfers(Stream.empty());
+
+        // Act
+        verify(jobStore).markJobInError(job.getJobId(), "Handler method failed");
+        verifyNoMoreInteractions(jobStore);
+        verifyNoInteractions(processManager);
+    }
+
+    @Test
+    void transferProcessCompleted_WhenJobNotFound_Ignore() {
+        // Arrange
+        when(jobStore.findByProcessId(transfer.getId()))
+                .thenReturn(Optional.empty());
+
+        // Act
+        callTransferProcessCompletedViaCallback();
+
+        // Act
+        verify(monitor).severe("Job not found for transfer " + transfer.getId());
+        verifyNoInteractions(handler);
+        verifyNoMoreInteractions(jobStore);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = JobState.class, names = "IN_PROGRESS", mode = EXCLUDE)
+    void transferProcessCompleted_WhenJobNotInProgress_Ignore(JobState state) {
+        // Arrange
+        job = job.toBuilder().state(state).build();
+
+        // Act
+        when(jobStore.findByProcessId(transfer.getId()))
+                .thenReturn(Optional.of(job));
+        callTransferProcessCompletedViaCallback();
+
+        // Act
+        verifyNoMoreInteractions(jobStore);
+        verifyNoInteractions(handler);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ResponseStatus.class, names = "OK", mode = EXCLUDE)
+    void transferProcessCompleted_WhenNextTransferStartUnsuccessful_Abort(ResponseStatus status) {
+        // Arrange
+        when(processManager.initiateConsumerRequest(dataRequest))
+                .thenReturn(generate.response(status));
+
+        // Act
+        callCompleteAndReturnNextTransfers(Stream.of(dataRequest, dataRequest2));
+
+        // Assert
+        verify(processManager).initiateConsumerRequest(dataRequest);
+        verify(processManager, never()).initiateConsumerRequest(dataRequest2);
+
+        // temporarily created job should be deleted
+        verify(jobStore).markJobInError(job.getJobId(), "Failed to start a transfer");
+        verifyNoMoreInteractions(jobStore);
+    }
+
+    @Test
+    void transferProcessCompleted_WhenHandlerRecurseThrows_StopJob() {
+        // Arrange
+        when(jobStore.findByProcessId(transfer.getId()))
+                .thenReturn(Optional.of(job));
+        when(handler.recurse(job, transfer))
+                .thenThrow(new RuntimeException());
+
+        // Act
+        callTransferProcessCompletedViaCallback();
+
+        // Assert
+        verify(jobStore).markJobInError(job.getJobId(), "Handler method failed");
+        verifyNoMoreInteractions(jobStore);
+        verifyNoInteractions(processManager);
+    }
+
+    private Object byCompletingJob() {
+        job.transitionTransfersFinished();
+        return null;
+    }
+
+    private MultiTransferJob startJob() {
+        sut.startJob(job.getJobData());
+        return getStartedJob();
+    }
+
+    private MultiTransferJob getStartedJob() {
+        verify(jobStore).create(jobCaptor.capture());
+        return jobCaptor.getValue();
+    }
+
+    private void callCompleteAndReturnNextTransfers(Stream<DataRequest> dataRequestStream) {
+        when(jobStore.findByProcessId(transfer.getId()))
+                .thenReturn(Optional.of(job));
+        when(handler.recurse(job, transfer))
+                .thenReturn(dataRequestStream);
+        callTransferProcessCompletedViaCallback();
+    }
+
+    private void callTransferProcessCompletedViaCallback() {
+        verify(transferProcessObservable).registerListener(callbackCaptor.capture());
+        callbackCaptor.getValue().completed(transfer);
+    }
+}

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/test/java/net/catenax/prs/connector/job/MultiTransferJobTest.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/test/java/net/catenax/prs/connector/job/MultiTransferJobTest.java
@@ -1,0 +1,30 @@
+package net.catenax.prs.connector.job;
+
+import com.github.javafaker.Faker;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class MultiTransferJobTest {
+
+    Faker faker = new Faker();
+    TestMother generate = new TestMother();
+
+    MultiTransferJob job = generate.job();
+
+    @Test
+    void getTransferProcessIds_Immutable() {
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() ->
+                        job.getTransferProcessIds().add(faker.lorem().word()));
+    }
+
+    @Test
+    void getJobData_Immutable() {
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() ->
+                        job.getJobData().put(
+                                faker.lorem().word(),
+                                faker.lorem().word()));
+    }
+}

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/test/java/net/catenax/prs/connector/job/TestMother.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/test/java/net/catenax/prs/connector/job/TestMother.java
@@ -1,0 +1,84 @@
+package net.catenax.prs.connector.job;
+
+import com.github.javafaker.Faker;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResponse;
+import org.eclipse.dataspaceconnector.spi.transfer.response.ResponseStatus;
+import org.eclipse.dataspaceconnector.spi.types.domain.metadata.DataEntry;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Base object mother class to create objects for testing.
+ *
+ * @see <a href="https://martinfowler.com/bliki/ObjectMother.html">
+ * https://martinfowler.com/bliki/ObjectMother.html</a>
+ */
+class TestMother {
+
+    Faker faker = new Faker();
+
+    MultiTransferJob job() {
+        return job(faker.options().option(JobState.class));
+    }
+
+    MultiTransferJob job(JobState jobState) {
+        return MultiTransferJob.builder()
+                .jobId(faker.lorem().characters())
+                .jobData(Map.of(
+                        faker.lorem().characters(),
+                        faker.lorem().characters(),
+                        faker.lorem().characters(),
+                        faker.lorem().characters()
+                ))
+                .state(jobState)
+                .build();
+    }
+
+    DataRequest dataRequest() {
+        return DataRequest.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .connectorAddress(faker.internet().url())
+                .protocol("ids-rest")
+                .connectorId("consumer")
+                .dataEntry(DataEntry.Builder.newInstance()
+                        .id("prs-request")
+                        .policyId("use-eu")
+                        .build())
+                .dataDestination(DataAddress.Builder.newInstance()
+                        .type(faker.lorem().word())
+                        .property("account", faker.lorem().word())
+                        .build())
+                .properties(Map.of(
+                        faker.lorem().word(), faker.lorem().word()
+                ))
+                .managedResources(true)
+                .build();
+    }
+
+    TransferInitiateResponse okResponse() {
+        return response(ResponseStatus.OK);
+    }
+
+    TransferInitiateResponse response(ResponseStatus status) {
+        return TransferInitiateResponse.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .status(status)
+                .build();
+    }
+
+    TransferProcess transfer() {
+        return TransferProcess.Builder.newInstance()
+                .id(faker.lorem().characters())
+                .build();
+    }
+
+    public Stream<DataRequest> dataRequests(int count) {
+        return IntStream.range(0, count).mapToObj(i -> dataRequest());
+    }
+}

--- a/coreservices/partsrelationshipservice/connector/pom.xml
+++ b/coreservices/partsrelationshipservice/connector/pom.xml
@@ -12,6 +12,7 @@
 
     <modules>
         <module>edc-patched-core</module>
+        <module>edc-recursive-job</module>
         <module>prs-connector-models</module>
         <module>prs-connector-consumer</module>
         <module>prs-connector-provider</module>

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/dataspaceconnector-configuration.properties
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/dataspaceconnector-configuration.properties
@@ -2,5 +2,5 @@ web.http.port=9191
 edc.vault.clientid=0dcdabb0-70db-4ada-8a6b-20cbb6519824
 edc.vault.tenantid=836f6094-147a-44cc-8064-3dd900228759
 edc.vault.certificate=/tmp/cert.pfx
-edc_vault_name=cxmtpdc1-dev-consumer
-edc_storage_account_name=cxmtpdc1devconsumer
+edc.vault.name=cxmtpdc1-dev-consumer
+edc.storage.account.name=cxmtpdc1devconsumer

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/pom.xml
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/pom.xml
@@ -111,5 +111,11 @@
       <version>${revision}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>net.catenax.prs</groupId>
+      <artifactId>edc-recursive-job</artifactId>
+      <version>${revision}</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/configuration/ConsumerConfiguration.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/configuration/ConsumerConfiguration.java
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
+package net.catenax.prs.connector.consumer.configuration;
+
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Configuration data for the consumer connector.
+ */
+@Value
+@Builder
+public class ConsumerConfiguration {
+
+    /**
+     * Storage account name.
+     */
+    private final String storageAccountName;
+}

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/controller/ConsumerApiController.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/controller/ConsumerApiController.java
@@ -24,9 +24,6 @@ import net.catenax.prs.connector.consumer.service.ConsumerService;
 import net.catenax.prs.connector.parameters.GetStatusParameters;
 import net.catenax.prs.connector.requests.FileRequest;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResponse;
-
-import java.util.Optional;
 
 /**
  * Consumer API Controller.
@@ -78,7 +75,7 @@ public class ConsumerApiController {
      *                Contains a PartsTreeByObjectIdRequest corresponding to prs-request and other
      *                information such that the destination file where the result of the PRS
      *                request should be written.
-     * @return TransferInitiateResponse with process id.
+     * @return Response with process id.
      */
     @POST
     @Path("file")
@@ -88,10 +85,9 @@ public class ConsumerApiController {
         return middleware.chain()
                 .validate(request)
                 .invoke(() -> {
-                    final Optional<TransferInitiateResponse> transferInfo;
-                    transferInfo = service.initiateTransfer(request);
-                    return transferInfo.isPresent()
-                            ? Response.ok(transferInfo.get().getId()).build()
+                    final var jobInfo = service.initiateTransfer(request);
+                    return jobInfo.isPresent()
+                            ? Response.ok(jobInfo.get().getJobId()).build()
                             : Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
                 });
     }

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/controller/ConsumerApiController.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/controller/ConsumerApiController.java
@@ -75,7 +75,7 @@ public class ConsumerApiController {
      *                Contains a PartsTreeByObjectIdRequest corresponding to prs-request and other
      *                information such that the destination file where the result of the PRS
      *                request should be written.
-     * @return Response with process id.
+     * @return Response with job id.
      */
     @POST
     @Path("file")
@@ -93,10 +93,10 @@ public class ConsumerApiController {
     }
 
     /**
-     * Provides status of a process
+     * Provides status of a job
      *
      * @param parameters request parameters
-     * @return Process state
+     * @return Job state
      */
     @GET
     @Path("datarequest/{id}/state")

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/extension/ApiEndpointExtension.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/extension/ApiEndpointExtension.java
@@ -9,18 +9,23 @@
 //
 package net.catenax.prs.connector.consumer.extension;
 
+
 import jakarta.validation.Validation;
 import net.catenax.prs.connector.annotations.ExcludeFromCodeCoverageGeneratedReport;
+import net.catenax.prs.connector.consumer.configuration.ConsumerConfiguration;
 import net.catenax.prs.connector.consumer.controller.ConsumerApiController;
 import net.catenax.prs.connector.consumer.middleware.RequestMiddleware;
 import net.catenax.prs.connector.consumer.service.ConsumerService;
+import net.catenax.prs.connector.consumer.service.PartsTreeRecursiveJobHandler;
 import net.catenax.prs.connector.consumer.transfer.FileStatusChecker;
+import net.catenax.prs.connector.job.InMemoryJobStore;
+import net.catenax.prs.connector.job.JobOrchestrator;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.protocol.web.WebService;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
-import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessObservable;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.StatusCheckerRegistry;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 
@@ -51,6 +56,9 @@ public class ApiEndpointExtension implements ServiceExtension {
 
     @Override
     public void initialize(final ServiceExtensionContext context) {
+        final var storageAccountName = ofNullable(context.getSetting(EDC_STORAGE_ACCOUNT_NAME, null))
+                .orElseThrow(() -> new EdcException("Missing mandatory property " + EDC_STORAGE_ACCOUNT_NAME));
+
         final var monitor = context.getMonitor();
 
         final var validator = Validation.byDefaultProvider()
@@ -60,14 +68,15 @@ public class ApiEndpointExtension implements ServiceExtension {
                 .getValidator();
 
         final var middleware = new RequestMiddleware(monitor, validator);
-
         final var webService = context.getService(WebService.class);
         final var processManager = context.getService(TransferProcessManager.class);
-        final var processStore = context.getService(TransferProcessStore.class);
-        final var storageAccountName = ofNullable(context.getSetting(EDC_STORAGE_ACCOUNT_NAME, null))
-                .orElseThrow(() -> new EdcException("Missing mandatory property " + EDC_STORAGE_ACCOUNT_NAME));
+        final var transferProcessObservable = context.getService(TransferProcessObservable.class);
+        final var jobStore = new InMemoryJobStore(monitor);
+        final var configuration = ConsumerConfiguration.builder().storageAccountName(storageAccountName).build();
+        final var jobHandler = new PartsTreeRecursiveJobHandler(monitor, configuration);
+        final var jobOrchestrator = new JobOrchestrator(processManager, jobStore, jobHandler, transferProcessObservable, monitor);
 
-        final var service = new ConsumerService(monitor, processManager, processStore, storageAccountName);
+        final var service = new ConsumerService(monitor, jobStore, jobOrchestrator);
 
         webService.registerController(new ConsumerApiController(monitor, service, middleware));
 

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/service/ConsumerService.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/service/ConsumerService.java
@@ -13,21 +13,16 @@ package net.catenax.prs.connector.consumer.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import net.catenax.prs.connector.job.JobInitiateResponse;
+import net.catenax.prs.connector.job.JobOrchestrator;
+import net.catenax.prs.connector.job.JobState;
+import net.catenax.prs.connector.job.JobStore;
+import net.catenax.prs.connector.job.MultiTransferJob;
 import net.catenax.prs.connector.requests.FileRequest;
-import org.eclipse.dataspaceconnector.schema.azure.AzureBlobStoreSchema;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResponse;
-import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
-import org.eclipse.dataspaceconnector.spi.transfer.response.ResponseStatus;
-import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
-import org.eclipse.dataspaceconnector.spi.types.domain.metadata.DataEntry;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataAddress;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 
 import static java.lang.String.format;
 
@@ -40,25 +35,25 @@ import static java.lang.String.format;
 public class ConsumerService {
 
     /**
-     * Logger.
+     * Key for the serialized request stored in the Job Data.
      */
-    private final Monitor monitor;
-    /**
-     * Sends messages to provider.
-     */
-    private final TransferProcessManager processManager;
-    /**
-     * Manages storage of TransferProcess state.
-     */
-    private final TransferProcessStore processStore;
-    /**
-     * Storage account name
-     */
-    private final String storageAccountName;
+    /* package */ static final String PARTS_REQUEST_KEY = "ser-request";
     /**
      * JSON object mapper.
      */
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    /**
+     * Logger.
+     */
+    private final Monitor monitor;
+    /**
+     * Job Orchestrator.
+     */
+    private final JobStore jobStore;
+    /**
+     * Job Orchestrator.
+     */
+    private final JobOrchestrator jobOrchestrator;
 
     /**
      * Endpoint to trigger a request, so that a file get copied into a specific destination.
@@ -66,53 +61,34 @@ public class ConsumerService {
      * @param request Request parameters.
      * @return TransferInitiateResponse with process id.
      */
-    public Optional<TransferInitiateResponse> initiateTransfer(final FileRequest request) {
+    public Optional<JobInitiateResponse> initiateTransfer(final FileRequest request) {
         monitor.info(format("Received request against provider %s", request.getConnectorAddress()));
 
         final String serializedRequest;
         try {
-            serializedRequest = MAPPER.writeValueAsString(request.getPartsTreeRequest());
+            serializedRequest = MAPPER.writeValueAsString(request);
         } catch (JsonProcessingException e) {
             // should not happen
             monitor.severe("Error serializing request", e);
             return Optional.empty();
         }
 
-        final var dataRequest = DataRequest.Builder.newInstance()
-                .id(UUID.randomUUID().toString()) //this is not relevant, thus can be random
-                .connectorAddress(request.getConnectorAddress()) //the address of the provider connector
-                .protocol("ids-rest") //must be ids-rest
-                .connectorId("consumer")
-                .dataEntry(DataEntry.Builder.newInstance() //the data entry is the source asset
-                        .id("prs-request")
-                        .policyId("use-eu")
-                        .build())
-                .dataDestination(DataAddress.Builder.newInstance()
-                        .type(AzureBlobStoreSchema.TYPE) //the provider uses this to select the correct DataFlowController
-                        .property("account", storageAccountName)
-                        .build())
-                .properties(Map.of(
-                        "prs-request-parameters", serializedRequest,
-                        "prs-destination-path", request.getDestinationPath()
-                ))
-                .managedResources(true)
-                .build();
-
-        final var response = processManager.initiateConsumerRequest(dataRequest);
-        return response.getStatus() == ResponseStatus.OK ? Optional.of(response) : Optional.empty();
+        final var response = jobOrchestrator.startJob(Map.of(
+                PARTS_REQUEST_KEY, serializedRequest
+        ));
+        return Optional.of(response);
     }
 
     /**
-     * Provides status of a process
+     * Provides status of a job
      *
-     * @param requestId If of the process
-     * @return Process state
+     * @param jobId If of the job
+     * @return Job state
      */
-    public Optional<TransferProcessStates> getStatus(final String requestId) {
-        monitor.info("Getting status of data request " + requestId);
+    public Optional<JobState> getStatus(final String jobId) {
+        monitor.info("Getting status of job " + jobId);
 
-        return Optional
-                .ofNullable(processStore.find(requestId))
-                .map(p -> TransferProcessStates.from(p.getState()));
+        return jobStore.find(jobId)
+                .map(MultiTransferJob::getState);
     }
 }

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/service/PartsTreeRecursiveJobHandler.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/service/PartsTreeRecursiveJobHandler.java
@@ -83,18 +83,18 @@ public class PartsTreeRecursiveJobHandler implements RecursiveJobHandler {
     }
 
     private Optional<DataRequest> dataRequest(final MultiTransferJob job) {
-        final var req = job.getJobData().get(ConsumerService.PARTS_REQUEST_KEY);
-        final FileRequest req2;
+        final var fileRequestAsString = job.getJobData().get(ConsumerService.PARTS_REQUEST_KEY);
+        final FileRequest fileRequest;
         try {
-            req2 = MAPPER.readValue(req, FileRequest.class);
+            fileRequest = MAPPER.readValue(fileRequestAsString, FileRequest.class);
         } catch (JsonProcessingException e) {
             monitor.severe("Error deserializing request", e);
             return Optional.empty();
         }
 
-        String req3;
+        String partsTreeRequestAsString;
         try {
-            req3 = MAPPER.writeValueAsString(req2.getPartsTreeRequest());
+            partsTreeRequestAsString = MAPPER.writeValueAsString(fileRequest.getPartsTreeRequest());
         } catch (JsonProcessingException e) {
             monitor.severe("Error serializing request", e);
             return Optional.empty();
@@ -102,7 +102,7 @@ public class PartsTreeRecursiveJobHandler implements RecursiveJobHandler {
 
         return Optional.of(DataRequest.Builder.newInstance()
                 .id(UUID.randomUUID().toString()) //this is not relevant, thus can be random
-                .connectorAddress(req2.getConnectorAddress()) //the address of the provider connector
+                .connectorAddress(fileRequest.getConnectorAddress()) //the address of the provider connector
                 .protocol("ids-rest") //must be ids-rest
                 .connectorId("consumer")
                 .dataEntry(DataEntry.Builder.newInstance() //the data entry is the source asset
@@ -114,8 +114,8 @@ public class PartsTreeRecursiveJobHandler implements RecursiveJobHandler {
                         .property("account", configuration.getStorageAccountName())
                         .build())
                 .properties(Map.of(
-                        "prs-request-parameters", req3,
-                        "prs-destination-path", req2.getDestinationPath()
+                        "prs-request-parameters", partsTreeRequestAsString,
+                        "prs-destination-path", fileRequest.getDestinationPath()
                 ))
                 .managedResources(true)
                 .build());

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/service/PartsTreeRecursiveJobHandler.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/service/PartsTreeRecursiveJobHandler.java
@@ -1,0 +1,123 @@
+//
+// Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+//
+// See the AUTHORS file(s) distributed with this work for additional
+// information regarding authorship.
+//
+// See the LICENSE file(s) distributed with this work for
+// additional information regarding license terms.
+//
+package net.catenax.prs.connector.consumer.service;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import net.catenax.prs.connector.consumer.configuration.ConsumerConfiguration;
+import net.catenax.prs.connector.job.MultiTransferJob;
+import net.catenax.prs.connector.job.RecursiveJobHandler;
+import net.catenax.prs.connector.requests.FileRequest;
+import org.eclipse.dataspaceconnector.schema.azure.AzureBlobStoreSchema;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.types.domain.metadata.DataEntry;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+/**
+ * Implementation of {@link RecursiveJobHandler} that retrieves
+ * the parts tree.
+ * <p>
+ * In this increment, the implementation only retrieves the first level
+ * parts tree, as a non-recursive implementation would do. In a next
+ * increment, this class will be extended to perform recursive queries
+ * by querying multiple PRS API instances.
+ */
+@RequiredArgsConstructor
+@SuppressWarnings("PMD.GuardLogStatement") // Monitor doesn't offer guard statements
+public class PartsTreeRecursiveJobHandler implements RecursiveJobHandler {
+
+    /**
+     * JSON object mapper.
+     */
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    /**
+     * Logger.
+     */
+    private final Monitor monitor;
+    /**
+     * Storage account name.
+     */
+    private final ConsumerConfiguration configuration;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Stream<DataRequest> initiate(final MultiTransferJob job) {
+        monitor.info("Initiating recursive retrieval for Job " + job.getJobId());
+        final var request = dataRequest(job);
+        return request.isPresent() ? Stream.of(request.get()) : Stream.empty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Stream<DataRequest> recurse(final MultiTransferJob job, final TransferProcess transferProcess) {
+        monitor.info("Proceeding with recursive retrieval for Job " + job.getJobId());
+        return Stream.of();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void complete(final MultiTransferJob job) {
+        monitor.info("Completed with recursive retrieval for Job " + job.getJobId());
+    }
+
+    private Optional<DataRequest> dataRequest(final MultiTransferJob job) {
+        final var req = job.getJobData().get(ConsumerService.PARTS_REQUEST_KEY);
+        final FileRequest req2;
+        try {
+            req2 = MAPPER.readValue(req, FileRequest.class);
+        } catch (JsonProcessingException e) {
+            monitor.severe("Error deserializing request", e);
+            return Optional.empty();
+        }
+
+        String req3;
+        try {
+            req3 = MAPPER.writeValueAsString(req2.getPartsTreeRequest());
+        } catch (JsonProcessingException e) {
+            monitor.severe("Error serializing request", e);
+            return Optional.empty();
+        }
+
+        return Optional.of(DataRequest.Builder.newInstance()
+                .id(UUID.randomUUID().toString()) //this is not relevant, thus can be random
+                .connectorAddress(req2.getConnectorAddress()) //the address of the provider connector
+                .protocol("ids-rest") //must be ids-rest
+                .connectorId("consumer")
+                .dataEntry(DataEntry.Builder.newInstance() //the data entry is the source asset
+                        .id("prs-request")
+                        .policyId("use-eu")
+                        .build())
+                .dataDestination(DataAddress.Builder.newInstance()
+                        .type(AzureBlobStoreSchema.TYPE) //the provider uses this to select the correct DataFlowController
+                        .property("account", configuration.getStorageAccountName())
+                        .build())
+                .properties(Map.of(
+                        "prs-request-parameters", req3,
+                        "prs-destination-path", req2.getDestinationPath()
+                ))
+                .managedResources(true)
+                .build());
+    }
+}

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/test/java/net/catenax/prs/connector/consumer/controller/ConsumerApiControllerTests.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/test/java/net/catenax/prs/connector/consumer/controller/ConsumerApiControllerTests.java
@@ -6,13 +6,13 @@ import jakarta.validation.Validator;
 import jakarta.ws.rs.core.Response;
 import net.catenax.prs.connector.consumer.middleware.RequestMiddleware;
 import net.catenax.prs.connector.consumer.service.ConsumerService;
+import net.catenax.prs.connector.job.JobInitiateResponse;
+import net.catenax.prs.connector.job.JobState;
 import net.catenax.prs.connector.parameters.GetStatusParameters;
 import net.catenax.prs.connector.requests.FileRequest;
 import org.eclipse.dataspaceconnector.monitor.ConsoleMonitor;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResponse;
 import org.eclipse.dataspaceconnector.spi.transfer.response.ResponseStatus;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -49,19 +49,19 @@ public class ConsumerApiControllerTests {
 
     GetStatusParameters parameters = new GetStatusParameters(UUID.randomUUID().toString());
 
-    TransferProcessStates status = faker.options().option(TransferProcessStates.class);
+    JobState jobStatus = faker.options().option(JobState.class);
 
     FileRequest fileRequest = FileRequest.builder()
             .connectorAddress(faker.internet().url())
             .destinationPath(faker.file().fileName())
             .build();
 
-    TransferInitiateResponse transferResponse = TransferInitiateResponse.Builder.newInstance()
-            .id(faker.lorem().characters())
+    JobInitiateResponse jobResponse = JobInitiateResponse.builder()
+            .jobId(faker.lorem().characters())
             .status(faker.options().option(ResponseStatus.class)).build();
 
     private ConstraintViolation<GetStatusParameters> getStatusViolation = mock(ConstraintViolation.class);
-   
+
     private ConstraintViolation<FileRequest> fileRequestViolation = mock(ConstraintViolation.class);
 
     @Test
@@ -81,12 +81,12 @@ public class ConsumerApiControllerTests {
     @Test
     public void initiateTransfer_WhenSuccess_ReturnsTransferId() {
         // Arrange
-        when(service.initiateTransfer(fileRequest)).thenReturn(Optional.of(transferResponse));
+        when(service.initiateTransfer(fileRequest)).thenReturn(Optional.of(jobResponse));
         // Act
         var response = controller.initiateTransfer(fileRequest);
         // Assert
         assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(response.getEntity()).isEqualTo(transferResponse.getId());
+        assertThat(response.getEntity()).isEqualTo(jobResponse.getJobId());
     }
 
     @Test
@@ -110,11 +110,11 @@ public class ConsumerApiControllerTests {
     @Test
     public void getStatus_WhenSuccess_ReturnsStatus() {
         // Arrange
-        when(service.getStatus(parameters.getRequestId())).thenReturn(Optional.of(status));
+        when(service.getStatus(parameters.getRequestId())).thenReturn(Optional.of(jobStatus));
         // Act
         var response = controller.getStatus(parameters);
         // Assert
-        assertThat(response.getEntity()).isEqualTo(status.name());
+        assertThat(response.getEntity()).isEqualTo(jobStatus.name());
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
     }
 

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/test/java/net/catenax/prs/connector/consumer/service/PartsTreeRecursiveJobHandlerTest.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/test/java/net/catenax/prs/connector/consumer/service/PartsTreeRecursiveJobHandlerTest.java
@@ -1,0 +1,107 @@
+package net.catenax.prs.connector.consumer.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.javafaker.Faker;
+import net.catenax.prs.connector.consumer.configuration.ConsumerConfiguration;
+import net.catenax.prs.connector.job.JobState;
+import net.catenax.prs.connector.job.MultiTransferJob;
+import net.catenax.prs.connector.requests.FileRequest;
+import org.eclipse.dataspaceconnector.monitor.ConsoleMonitor;
+import org.eclipse.dataspaceconnector.schema.azure.AzureBlobStoreSchema;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.types.domain.metadata.DataEntry;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@ExtendWith(MockitoExtension.class)
+class PartsTreeRecursiveJobHandlerTest {
+
+    static final ObjectMapper MAPPER = new ObjectMapper();
+    Faker faker = new Faker();
+    Monitor monitor = new ConsoleMonitor();
+    ConsumerConfiguration configuration = ConsumerConfiguration.builder()
+            .storageAccountName(faker.lorem().characters())
+            .build();
+    PartsTreeRecursiveJobHandler sut;
+    MultiTransferJob job = MultiTransferJob.builder()
+            .jobId(faker.lorem().characters())
+            .state(faker.options().option(JobState.class))
+            .build();
+    TransferProcess transfer = TransferProcess.Builder.newInstance()
+            .id(faker.lorem().characters())
+            .build();
+    private final RequestMother generate = new RequestMother();
+    private final FileRequest fileRequest = generate.fileRequest();
+
+    @BeforeEach
+    public void setUp() {
+        sut = new PartsTreeRecursiveJobHandler(monitor, configuration);
+    }
+
+    @Test
+    void initiate() throws Exception {
+        // Arrange
+        String serializedRequest1 = MAPPER.writeValueAsString(fileRequest);
+        String serializedRequest2 = MAPPER.writeValueAsString(fileRequest.getPartsTreeRequest());
+
+        job = job.toBuilder().jobData(Map.of(ConsumerService.PARTS_REQUEST_KEY, serializedRequest1)).build();
+
+        // Act
+        var result = sut.initiate(job);
+
+        // Assert
+        var resultAsList = result.collect(Collectors.toList());
+        assertThat(resultAsList).hasSize(1);
+
+        // Verify that initiateConsumerRequest got called with correct DataRequest input.
+        var expectedDataRequest = DataRequest.Builder.newInstance()
+                .id(resultAsList.get(0).getId())
+                .connectorAddress(fileRequest.getConnectorAddress())
+                .protocol("ids-rest")
+                .connectorId("consumer")
+                .dataEntry(DataEntry.Builder.newInstance()
+                        .id("prs-request")
+                        .policyId("use-eu")
+                        .build())
+                .dataDestination(DataAddress.Builder.newInstance()
+                        .type(AzureBlobStoreSchema.TYPE)
+                        .property("account", configuration.getStorageAccountName())
+                        .build())
+                .properties(Map.of(
+                        "prs-request-parameters", serializedRequest2,
+                        "prs-destination-path", fileRequest.getDestinationPath()
+                ))
+                .managedResources(true)
+                .build();
+
+        assertThat(resultAsList)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(expectedDataRequest);
+    }
+
+    @Test
+    void recurse() {
+        // Act
+        var result = sut.recurse(job, transfer);
+
+        // Assert
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void complete() {
+        // Act
+        sut.complete(job);
+    }
+}

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/test/java/net/catenax/prs/connector/consumer/service/RequestMother.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/test/java/net/catenax/prs/connector/consumer/service/RequestMother.java
@@ -1,0 +1,29 @@
+package net.catenax.prs.connector.consumer.service;
+
+import com.github.javafaker.Faker;
+import net.catenax.prs.connector.requests.FileRequest;
+import net.catenax.prs.connector.requests.PartsTreeByObjectIdRequest;
+
+public class RequestMother {
+
+    Faker faker = new Faker();
+
+    PartsTreeByObjectIdRequest request() {
+        return PartsTreeByObjectIdRequest.builder()
+                .oneIDManufacturer(faker.company().name())
+                .objectIDManufacturer(faker.lorem().characters(10, 20))
+                .view("AS_BUILT")
+                .depth(faker.number().numberBetween(1, 5))
+                .build();
+
+    }
+
+    FileRequest fileRequest() {
+        return FileRequest.builder()
+                .connectorAddress(faker.internet().url())
+                .destinationPath(faker.file().fileName())
+                .partsTreeRequest(request())
+                .build();
+    }
+
+}

--- a/coreservices/partsrelationshipservice/connector/run-integration-test.sh
+++ b/coreservices/partsrelationshipservice/connector/run-integration-test.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 set -euo pipefail
-
-if ! [ -f /tmp/cert.pfx ]; then
-  echo "ERROR: Missing file /tmp/cert.pfx (see README.md)"
-  exit 1
-fi
-
 cd ..
 export DOCKER_BUILDKIT=1
 docker-compose --profile connector build --build-arg PRS_EDC_PKG_USERNAME=$PRS_EDC_PKG_USERNAME --build-arg PRS_EDC_PKG_PASSWORD=$PRS_EDC_PKG_PASSWORD

--- a/coreservices/partsrelationshipservice/connector/run-integration-test.sh
+++ b/coreservices/partsrelationshipservice/connector/run-integration-test.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 set -euo pipefail
+
+if ! [ -f /tmp/cert.pfx ]; then
+  echo "ERROR: Missing file /tmp/cert.pfx (see README.md)"
+  exit 1
+fi
+
 cd ..
 export DOCKER_BUILDKIT=1
 docker-compose --profile connector build --build-arg PRS_EDC_PKG_USERNAME=$PRS_EDC_PKG_USERNAME --build-arg PRS_EDC_PKG_PASSWORD=$PRS_EDC_PKG_PASSWORD


### PR DESCRIPTION
The logic to orchestate multiple transfers (to build a PRS parts tree out of recursive calls to PRS API endpoints in multiple dataspace partitions) is factored out into a generic framework to manage jobs, that allows plugging in a custom handler to provide the logic, in our case to parse the output of one PRS API call to determine the next endpoints to call.

This PR is only the job framework. The custom logic is as before, and runs only a single PRS API call. Further PRs willl build on this to run recursive PRS API calls.

Note that jobs accumulate in in-memory storage. Created follow-up task 179 to deal with memory management since this could be a broader topic including blob storage cleanup.
