### PR TITLE
Fix issue with logs format used by ConsoleHandler

### DIFF
--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/resources/logging.properties
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/resources/logging.properties
@@ -2,6 +2,6 @@ handlers = java.util.logging.ConsoleHandler
 .level = INFO
 java.util.logging.ConsoleHandler.level = ALL
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
-java.util.logging.SimpleFormatter.format = %d %-5level %logger : %msg%n
+java.util.logging.SimpleFormatter.format = %1$tF %1$tT %4$s : %5$s %n
 net.catenax.prs.level = INFO
 net.catenax.prs.handler = java.util.logging.ConsoleHandler

--- a/coreservices/partsrelationshipservice/connector/prs-connector-provider/src/main/resources/logging.properties
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-provider/src/main/resources/logging.properties
@@ -2,6 +2,6 @@ handlers = java.util.logging.ConsoleHandler
 .level = INFO
 java.util.logging.ConsoleHandler.level = ALL
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
-java.util.logging.SimpleFormatter.format = %d %-5level %logger : %msg%n
+java.util.logging.SimpleFormatter.format = %1$tF %1$tT %4$s : %5$s %n
 net.catenax.prs.level = INFO
 net.catenax.prs.handler = java.util.logging.ConsoleHandler


### PR DESCRIPTION
After merging the PR #277 we spot an issue with a log formatting when running application locally. the issue was that the value of `java.util.logging.SimpleFormatter.format` property in logging.properties file was not parsed correctly and that's why the default logging format has been chosen. 