### PR TITLE
Semantic Hub: Implement pagination response info in model query

### DIFF
--- a/semantics/services/semantic-hub-openapi.yaml
+++ b/semantics/services/semantic-hub-openapi.yaml
@@ -342,9 +342,31 @@ components:
             - RELEASED
             - DEPRECATED
     ModelList:
-      type: array
-      items:
-        $ref: '#/components/schemas/Model'
+      required:
+        - items
+        - totalItems
+        - currentPage
+        - totalPages
+        - itemCount
+      type: object
+      properties:
+        items:
+          title: Items
+          type: array
+          items:
+            $ref: '#/components/schemas/Model'
+        totalItems:
+          title: Totalitems
+          type: integer
+        currentPage:
+          title: Currentpage
+          type: integer
+        totalPages:
+          title: Totalpages
+          type: integer
+        itemCount:
+          title: Itemcount
+          type: integer
     NewModel:
       type: object
       properties:

--- a/semantics/services/src/main/java/net/catenax/semantics/hub/ModelsService.java
+++ b/semantics/services/src/main/java/net/catenax/semantics/hub/ModelsService.java
@@ -16,7 +16,6 @@
 
 package net.catenax.semantics.hub;
 
-import java.util.List;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -36,6 +35,7 @@ import io.vavr.control.Try;
 import net.catenax.semantics.hub.api.ModelsApiDelegate;
 import net.catenax.semantics.hub.bamm.BammHelper;
 import net.catenax.semantics.hub.model.Model;
+import net.catenax.semantics.hub.model.ModelList;
 import net.catenax.semantics.hub.model.NewModel;
 import net.catenax.semantics.hub.persistence.PersistenceLayer;
 
@@ -49,7 +49,7 @@ public class ModelsService implements ModelsApiDelegate {
     BammHelper bamm;
 
     @Override
-    public ResponseEntity<List<Model>> getModelList(Integer pageSize, Integer page, String namespaceFilter,
+    public ResponseEntity<ModelList> getModelList(Integer pageSize, Integer page, String namespaceFilter,
             String nameFilter, String nameType, Boolean isPrivate, String type, String status) {
 
         try {
@@ -60,9 +60,9 @@ public class ModelsService implements ModelsApiDelegate {
             String decodedNamespace=java.net.URLDecoder.decode(namespaceFilter, java.nio.charset.StandardCharsets.UTF_8.name());
             String decodedName=java.net.URLDecoder.decode(nameFilter, java.nio.charset.StandardCharsets.UTF_8.name());
             
-            List<Model> list = ps.getModels(isPrivate, decodedNamespace, decodedName, decodedType, type, status, page, pageSize);
+            ModelList list = ps.getModels(isPrivate, decodedNamespace, decodedName, decodedType, type, status, page, pageSize);
 
-            return new ResponseEntity<List<Model>>(list, HttpStatus.OK);
+            return new ResponseEntity(list, HttpStatus.OK);
         } catch(java.io.UnsupportedEncodingException uee) {
             return new  ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }

--- a/semantics/services/src/main/java/net/catenax/semantics/hub/persistence/PersistenceLayer.java
+++ b/semantics/services/src/main/java/net/catenax/semantics/hub/persistence/PersistenceLayer.java
@@ -16,13 +16,13 @@
 
 package net.catenax.semantics.hub.persistence;
 
-import java.util.List;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
 
 import io.vavr.control.Try;
 import net.catenax.semantics.hub.model.Model;
+import net.catenax.semantics.hub.model.ModelList;
 import net.catenax.semantics.hub.model.NewModel;
 
 /**
@@ -41,7 +41,7 @@ public interface PersistenceLayer {
      * @param pageSize size of the pages to batch the results in
      * @return a list of models belonging to the searched page
      */
-    public List<Model> getModels(@Nullable Boolean isPrivate, String namespaceFilter, String nameFilter, @Nullable String nameType, @Nullable String type, @Nullable String status, int page, int pageSize);
+    public ModelList getModels(@Nullable Boolean isPrivate, String namespaceFilter, String nameFilter, @Nullable String nameType, @Nullable String type, @Nullable String status, int page, int pageSize);
 
     public Model getModel(String modelId);
 

--- a/semantics/services/src/main/java/net/catenax/semantics/hub/persistence/RDBMSPersistence.java
+++ b/semantics/services/src/main/java/net/catenax/semantics/hub/persistence/RDBMSPersistence.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Component;
 
 import io.vavr.control.Try;
 import net.catenax.semantics.hub.model.Model;
+import net.catenax.semantics.hub.model.ModelList;
 import net.catenax.semantics.hub.model.NewModel;
 import net.catenax.semantics.hub.persistence.mapper.SemanticModelMapper;
 import net.catenax.semantics.hub.persistence.model.ModelEntity;
@@ -43,7 +44,7 @@ public class RDBMSPersistence implements PersistenceLayer {
     ModelRepository mr;
 
     @Override
-    public List<Model> getModels(@Nullable Boolean isPrivate, String namespaceFilter, String nameFilter, @Nullable String nameType, @Nullable String type, @Nullable String status, int page, int pageSize) {
+    public ModelList getModels(@Nullable Boolean isPrivate, String namespaceFilter, String nameFilter, @Nullable String nameType, @Nullable String type, @Nullable String status, int page, int pageSize) {
         Pageable pageOptions = PageRequest.of(page, pageSize);
 
         Page<ModelEntity> result = null;
@@ -68,7 +69,14 @@ public class RDBMSPersistence implements PersistenceLayer {
 
         List<Model> modelList = mapper.modelEntityListToModelDtoList(result.toList());
 
-        return modelList;
+        ModelList modelListObject = new ModelList();
+        modelListObject.setItems(modelList);
+        modelListObject.setCurrentPage(result.getNumber());
+        modelListObject.setItemCount(result.getNumberOfElements());
+        modelListObject.setTotalItems((int) result.getTotalElements());
+        modelListObject.setTotalPages(result.getTotalPages());
+
+        return modelListObject;
     }
 
     @Override

--- a/semantics/services/src/test/java/net/catenax/semantics/hub/ModelsApiTest.java
+++ b/semantics/services/src/test/java/net/catenax/semantics/hub/ModelsApiTest.java
@@ -40,7 +40,7 @@ public class ModelsApiTest {
             .accept(MediaType.APPLICATION_JSON)
         )
         .andDo(MockMvcResultHandlers.print())
-        .andExpect(MockMvcResultMatchers.content().json("[{'private':false,'id':'urn:bamm:net.catenax:1.0.0#Movement','publisher':'Publisher','version':'1.0.0','name':'Movement','type':'BAMM','status':'DRAFT'}]"))
+        .andExpect(MockMvcResultMatchers.content().json("{'items':[{'private':false,'id':'urn:bamm:net.catenax:1.0.0#Movement','publisher':'Publisher','version':'1.0.0','name':'Movement','type':'BAMM','status':'DRAFT'}],'totalItems':1,'currentPage':0,'totalPages':1,'itemCount':1}"))
         .andExpect(MockMvcResultMatchers.status().isOk());
     }
 
@@ -189,7 +189,7 @@ public class ModelsApiTest {
             .accept(MediaType.APPLICATION_JSON)
         )
         .andDo(MockMvcResultHandlers.print())
-        .andExpect(MockMvcResultMatchers.content().json("[{'private':false,'id':'urn:bamm:net.catenax:1.0.0#Movement','publisher':'Publisher','version':'1.0.0','name':'Movement','type':'BAMM', 'status':'DRAFT'}]"))
+        .andExpect(MockMvcResultMatchers.content().json("{'items':[{'private':false,'id':'urn:bamm:net.catenax:1.0.0#Movement','publisher':'Publisher','version':'1.0.0','name':'Movement','type':'BAMM','status':'DRAFT'}],'totalItems':1,'currentPage':0,'totalPages':1,'itemCount':1}"))
         .andExpect(MockMvcResultMatchers.status().isOk());
     }
 
@@ -201,7 +201,7 @@ public class ModelsApiTest {
             .accept(MediaType.APPLICATION_JSON)
         )
         .andDo(MockMvcResultHandlers.print())
-        .andExpect(MockMvcResultMatchers.content().json("[{'private':false,'id':'urn:bamm:net.catenax:1.0.0#Movement','publisher':'Publisher','version':'1.0.0','name':'Movement','type':'BAMM', 'status':'DRAFT'}]"))
+        .andExpect(MockMvcResultMatchers.content().json("{'items':[{'private':false,'id':'urn:bamm:net.catenax:1.0.0#Movement','publisher':'Publisher','version':'1.0.0','name':'Movement','type':'BAMM','status':'DRAFT'}],'totalItems':1,'currentPage':0,'totalPages':1,'itemCount':1}"))
         .andExpect(MockMvcResultMatchers.status().isOk());
     }
 
@@ -213,7 +213,7 @@ public class ModelsApiTest {
             .accept(MediaType.APPLICATION_JSON)
         )
         .andDo(MockMvcResultHandlers.print())
-        .andExpect(MockMvcResultMatchers.content().json("[{'private':false,'id':'urn:bamm:net.catenax:1.0.0#Movement','publisher':'Publisher','version':'1.0.0','name':'Movement','type':'BAMM', 'status':'DRAFT'}]"))
+        .andExpect(MockMvcResultMatchers.content().json("{'items':[{'private':false,'id':'urn:bamm:net.catenax:1.0.0#Movement','publisher':'Publisher','version':'1.0.0','name':'Movement','type':'BAMM','status':'DRAFT'}],'totalItems':1,'currentPage':0,'totalPages':1,'itemCount':1}"))
         .andExpect(MockMvcResultMatchers.status().isOk());
     }
 


### PR DESCRIPTION
This commit modifies the response payload structure of the model list endpoint to also contain pagination details.