### PR TITLE
Feature/a1 mtdc@165 blob fix

### DIFF
--- a/.github/workflows/partsrelationshipservice-connector.yml
+++ b/.github/workflows/partsrelationshipservice-connector.yml
@@ -26,11 +26,8 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Configure certificate location
-        run: echo "edc_vault_certificate=$HOME/cert.pfx" >> $GITHUB_ENV
-
       - name: Download certificate
-        run: az keyvault secret download --file $edc_vault_certificate --vault-name "cxmtpdc1-dev-prs-id" --name "prs-connector-consumer-certificate" --encoding base64
+        run: az keyvault secret download --file ../dev/local/cert.pfx --vault-name "cxmtpdc1-dev-prs-id" --name "prs-connector-consumer-certificate" --encoding base64
 
       - name: Run sample test
         timeout-minutes: 15

--- a/coreservices/partsrelationshipservice/.gitignore
+++ b/coreservices/partsrelationshipservice/.gitignore
@@ -49,5 +49,5 @@ terraform-outputs-safe.json
 ### Maven generated files ###
 .flattened-pom.xml
 
-### CI-generated files ###
-dataspace-deployments.json
+### Local files ###
+dev/local/*

--- a/coreservices/partsrelationshipservice/connector/README.md
+++ b/coreservices/partsrelationshipservice/connector/README.md
@@ -28,7 +28,7 @@ Download certificate for the PRS Connector Consumer to communicate with its Key 
 
 ```sh
 terraform init
-az keyvault secret download --file /tmp/cert.pfx --vault-name "$(terraform output -raw vault_name)" --name "$(terraform output -raw prs_connector_consumer_cert_name)" --encoding base64
+az keyvault secret download --file ../../dev/local/cert.pfx --vault-name "$(terraform output -raw vault_name)" --name "$(terraform output -raw prs_connector_consumer_cert_name)" --encoding base64
 ```
 
 Set environment variables for GitHub access:

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobOrchestrator.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobOrchestrator.java
@@ -110,7 +110,7 @@ public class JobOrchestrator {
 
         // If no transfers are requested, job is already complete
         if (transferCount == 0) {
-            jobStore.completeJob(job.getJobId());
+            completeJob(job);
         }
 
         return JobInitiateResponse.builder().jobId(job.getJobId()).status(ResponseStatus.OK).build();
@@ -159,14 +159,18 @@ public class JobOrchestrator {
             if (job.getState() != JobState.TRANSFERS_FINISHED) {
                 return;
             }
-            try {
-                handler.complete(job);
-            } catch (RuntimeException e) {
-                markJobInError(job, e, "Handler method failed");
-                return;
-            }
-            jobStore.completeJob(job.getJobId());
+            completeJob(job);
         });
+    }
+
+    private void completeJob(final MultiTransferJob job) {
+        try {
+            handler.complete(job);
+        } catch (RuntimeException e) {
+            markJobInError(job, e, "Handler method failed");
+            return;
+        }
+        jobStore.completeJob(job.getJobId());
     }
 
     private void markJobInError(final MultiTransferJob job, final Throwable exception, final String message) {

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/test/java/net/catenax/prs/connector/job/JobOrchestratorTest.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/test/java/net/catenax/prs/connector/job/JobOrchestratorTest.java
@@ -127,6 +127,7 @@ class JobOrchestratorTest {
         verifyNoInteractions(processManager);
         verify(jobStore).completeJob(newJob.getJobId());
         verifyNoMoreInteractions(jobStore);
+        verify(handler).complete(newJob);
 
         assertThat(response)
                 .isEqualTo(

--- a/coreservices/partsrelationshipservice/connector/run-integration-test.sh
+++ b/coreservices/partsrelationshipservice/connector/run-integration-test.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 cd ..
+
+if [ ! -f dev/local/cert.pfx ]; then
+    echo "Missing file cert.pfx"
+    exit 1
+fi
+
 export DOCKER_BUILDKIT=1
 docker-compose --profile connector build --build-arg PRS_EDC_PKG_USERNAME=$PRS_EDC_PKG_USERNAME --build-arg PRS_EDC_PKG_PASSWORD=$PRS_EDC_PKG_PASSWORD
 docker-compose --profile connector --profile prs up --exit-code-from=connector-integration-test --abort-on-container-exit

--- a/coreservices/partsrelationshipservice/dev/connector-integration-test.sh
+++ b/coreservices/partsrelationshipservice/dev/connector-integration-test.sh
@@ -11,7 +11,7 @@ chmod +x retry
 ./wait-for-it.sh -t 60 consumer:8181
 ./wait-for-it.sh -t 60 prs:8080
 requestId=$(curl -f -X POST http://consumer:8181/api/v0.1/file -H "Content-type:application/json" -d '{"connectorAddress": "http://provider:8181", "partsTreeRequest": {
-                "oneIDManufacturer": "CAXSWPFTJQEVZNZZ", "objectIDManufacturer": "YS3DD78N4X7055320", "view": "AS_BUILT", "aspect": "MATERIAL", "depth": 2}}')
+                "oneIDManufacturer": "BMW MUC", "objectIDManufacturer": "YS3DD78N4X7055320", "view": "AS_BUILT", "aspect": "MATERIAL", "depth": 2}}')
 
 stateUrl="http://consumer:8181/api/v0.1/datarequest/$requestId/state"
 

--- a/coreservices/partsrelationshipservice/dev/connector-integration-test.sh
+++ b/coreservices/partsrelationshipservice/dev/connector-integration-test.sh
@@ -11,7 +11,7 @@ chmod +x retry
 ./wait-for-it.sh -t 60 consumer:8181
 ./wait-for-it.sh -t 60 prs:8080
 requestId=$(curl -f -X POST http://consumer:8181/api/v0.1/file -H "Content-type:application/json" -d '{"connectorAddress": "http://provider:8181", "partsTreeRequest": {
-                "oneIDManufacturer": "BMW", "objectIDManufacturer": "YS3DD78N4X7055320", "view": "AS_BUILT", "aspect": "MATERIAL", "depth": 2}}')
+                "oneIDManufacturer": "CAXSWPFTJQEVZNZZ", "objectIDManufacturer": "YS3DD78N4X7055320", "view": "AS_BUILT", "aspect": "MATERIAL", "depth": 2}}')
 
 stateUrl="http://consumer:8181/api/v0.1/datarequest/$requestId/state"
 

--- a/coreservices/partsrelationshipservice/dev/local/.marker
+++ b/coreservices/partsrelationshipservice/dev/local/.marker
@@ -1,0 +1,1 @@
+This directory is reserved for files that are produced locally and should not be committed.

--- a/coreservices/partsrelationshipservice/docker-compose.yml
+++ b/coreservices/partsrelationshipservice/docker-compose.yml
@@ -116,9 +116,7 @@ services:
       - 9191:8181
       - 4007:4006
     volumes:
-      - ./cd:/cd
       - ./dev/local:/devlocal
-      - ./dev/connector-integration-test-files:/files
 
   connector-integration-test:
     profiles:

--- a/coreservices/partsrelationshipservice/docker-compose.yml
+++ b/coreservices/partsrelationshipservice/docker-compose.yml
@@ -109,14 +109,16 @@ services:
       APPLICATIONINSIGHTS_ROLE_NAME: connector-consumer
       edc.vault.clientid: ${edc_vault_clientid}
       edc.vault.tenantid: ${edc_vault_tenantid}
-      edc.vault.certificate: /cert.pfx
+      edc.vault.certificate: /devlocal/cert.pfx
       edc.vault.name: ${edc_vault_name}
       edc.storage.account.name: ${edc_storage_account_name}
     ports:
       - 9191:8181
       - 4007:4006
     volumes:
-      - ${edc_vault_certificate}:/cert.pfx
+      - ./cd:/cd
+      - ./dev/local:/devlocal
+      - ./dev/connector-integration-test-files:/files
 
   connector-integration-test:
     profiles:


### PR DESCRIPTION
Some fixes for the previous PRs on blob storage and distributed PRS:
- Mount a directory rather than a file in docker-compose. If mounting a file directly, if the file doesn't exist previously, docker-compose creates a directory at that location which blocks file download, it also messes up the image and makes fixing this a pain.
- Use a proper One ID in docker-compose tests.
- Call complete() handler if no transfers are run.