### PR TITLE
Updating appinsight java agent to latest version

### DIFF
--- a/coreservices/partsrelationshipservice/Dockerfile
+++ b/coreservices/partsrelationshipservice/Dockerfile
@@ -41,7 +41,7 @@ FROM maven:3-jdk-11 AS wget
 
 # Java app insight agent version: https://docs.microsoft.com/en-us/azure/azure-monitor/app/java-in-process-agent
 # See https://confluence.catena-x.net/display/CXM/PRS+Observability
-ARG appInsightsAgentVersion="3.1.1"
+ARG appInsightsAgentVersion="3.2.3"
 ARG appInsightsAgentURL="https://github.com/microsoft/ApplicationInsights-Java/releases/download/${appInsightsAgentVersion}/applicationinsights-agent-${appInsightsAgentVersion}.jar"
 
 # jmx exporter version: https://github.com/prometheus/jmx_exporter/releases


### PR DESCRIPTION
- Updating appinsight java agent to latest version 3.2.3
- Done in order to improve tracing of consumer & provider edc connectors