### PR TITLE
Use deployment for edc provider instead of stateful set

### DIFF
--- a/coreservices/partsrelationshipservice/cd/helm/prs-connector-provider/templates/deployment.yaml
+++ b/coreservices/partsrelationshipservice/cd/helm/prs-connector-provider/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: prs-connector-provider
   labels:
@@ -10,7 +10,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: prs-connector-provider
-  serviceName: "prs-connector-consumer"
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Using a K8S deployment for EDC providers as no statefulset required anymore (sticky pod identity not required). EDC consumer still requires a statefulset to guarantee that polling the state endpoint goes to the same pod that initiated the transfer.

Successful deployment: https://github.com/catenax/tractusx/actions/runs/1500330841