### PR TITLE
Initial PR for stress tests

### DIFF
--- a/coreservices/partsrelationshipservice/cd/dataspace-partitions.json
+++ b/coreservices/partsrelationshipservice/cd/dataspace-partitions.json
@@ -20,13 +20,13 @@
       ]
     },
     {
-      "key": "BASF",
+      "key": "basf",
       "OneIDs": [
         "CAXLBRHHQAJAIOZZ"
       ]
     },
     {
-      "key": "HENKEL",
+      "key": "henkel",
       "OneIDs": [
         "CAXLHNJURNRLPCZZ"
       ]

--- a/coreservices/partsrelationshipservice/cd/dataspace-partitions.json
+++ b/coreservices/partsrelationshipservice/cd/dataspace-partitions.json
@@ -16,8 +16,6 @@
     {
       "key": "zf",
       "OneIDs": [
-        "CAXLBRHHQAJAIOZZ",
-        "CAXLHNJURNRLPCZZ",
         "CAXSJRTGOPVESVZZ"
       ]
     },

--- a/coreservices/partsrelationshipservice/cd/dataspace-partitions.json
+++ b/coreservices/partsrelationshipservice/cd/dataspace-partitions.json
@@ -20,6 +20,18 @@
         "CAXLHNJURNRLPCZZ",
         "CAXSJRTGOPVESVZZ"
       ]
+    },
+    {
+      "key": "BASF",
+      "OneIDs": [
+        "CAXLBRHHQAJAIOZZ"
+      ]
+    },
+    {
+      "key": "HENKEL",
+      "OneIDs": [
+        "CAXLHNJURNRLPCZZ"
+      ]
     }
   ]
 }

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorPerformanceTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorPerformanceTest.java
@@ -1,19 +1,8 @@
 package net.catenax.prs.systemtest;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gatling.javaapi.core.CoreDsl;
-import io.gatling.javaapi.core.ScenarioBuilder;
-import io.gatling.javaapi.core.Simulation;
-import io.gatling.javaapi.http.HttpDsl;
-import io.gatling.javaapi.http.HttpProtocolBuilder;
-import net.catenax.prs.connector.requests.PartsTreeByObjectIdRequest;
-import net.catenax.prs.connector.requests.PartsTreeRequest;
-import net.catenax.prs.dtos.PartsTreeView;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-
-import java.time.Duration;
 
 /**
  * This class is responsible for running a performance test on connectors integrated with PRS.
@@ -22,60 +11,12 @@ import java.time.Duration;
 public class PrsConnectorPerformanceTest extends SystemTestsBase {
     @Test
     public void test() {
-        runGatling(Runner.class);
+        runGatling(PerformanceTestsRunner.class);
     }
 
-    public static class Runner extends Simulation {
-
-        private static final String connectorUri = System.getenv().getOrDefault("ConnectorURI", "https://catenaxdev001akssrv.germanywestcentral.cloudapp.azure.com/prs-connector-consumer/api/v0.1");
-        private static final String VEHICLE_ONEID = "CAXSWPFTJQEVZNZZ";
-        private static final String VEHICLE_OBJECTID = "UVVZI9PKX5D37RFUB";
-        private static final int DEPTH_VALUE = 2;
-        private static final ObjectMapper MAPPER = new ObjectMapper();
-
-        private HttpProtocolBuilder httpProtocol = HttpDsl.http.baseUrl(connectorUri)
-                .acceptHeader("*/*").contentTypeHeader("application/json");
-
-        // Trigger a get parts tree request. Then call status endpoint every second till it returns 200.
-        private ScenarioBuilder scenarioBuilder = CoreDsl.scenario("Trigger Get parts tree for a part.")
-                // TODO: Decide right configurations (how many repeat, and how many users at once)
-                .repeat(1)
-                .on(CoreDsl.exec(
-                        HttpDsl.http("Trigger partsTree request")
-                                .post("/retrievePartsTree")
-                                .body(CoreDsl.StringBody(getSerializedPartsTreeRequest()))
-                                .check(HttpDsl.status().is(200)).check(CoreDsl.bodyString().saveAs("requestId"))
-                )
-                        // Call status endpoint every second, till it gives a 200 status code.
-                        .exec(session -> session.set("status", -1))
-                        .group("waitForCompletion").on(
-                                CoreDsl.doWhileDuring(session -> session.getInt("status") != 200, Duration.ofSeconds(12))
-                                        .on(CoreDsl.exec(HttpDsl.http("Get status")
-                                                .get(session -> String.format("/datarequest/%s/state", session.getString("requestId")))
-                                                .check(HttpDsl.status().saveAs("status")))
-                                                .pause(Duration.ofSeconds(1)))));
-
+    public static class PerformanceTestsRunner extends Runner {
         {
             setUp(scenarioBuilder.injectOpen(CoreDsl.atOnceUsers(10))).protocols(httpProtocol);
-        }
-
-        private static String getSerializedPartsTreeRequest() {
-            var params = PartsTreeRequest.builder()
-                    .byObjectIdRequest(
-                            PartsTreeByObjectIdRequest.builder()
-                                    .oneIDManufacturer(VEHICLE_ONEID)
-                                    .objectIDManufacturer(VEHICLE_OBJECTID)
-                                    .view(PartsTreeView.AS_BUILT.name())
-                                    .aspect(ASPECT_MATERIAL)
-                                    .depth(DEPTH_VALUE)
-                                    .build()).build();
-
-            try {
-                return MAPPER.writeValueAsString(params);
-            } catch (JsonProcessingException e) {
-                e.printStackTrace();
-                throw new RuntimeException("Exception serializing parts tree request", e);
-            }
         }
     }
 

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorPerformanceTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorPerformanceTest.java
@@ -20,5 +20,4 @@ public class PrsConnectorPerformanceTest extends SystemTestsBase {
             setUp(scenarioBuilder.injectOpen(CoreDsl.atOnceUsers(10))).protocols(httpProtocol);
         }
     }
-
 }

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorPerformanceTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorPerformanceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
  */
 @Tag("SystemTests")
 public class PrsConnectorPerformanceTest extends SystemTestsBase {
+
     @Test
     public void test() {
         runGatling(PerformanceTestsRunner.class);

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorPerformanceTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorPerformanceTest.java
@@ -1,8 +1,9 @@
 package net.catenax.prs.systemtest;
 
-import io.gatling.javaapi.core.CoreDsl;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import static io.gatling.javaapi.core.CoreDsl.atOnceUsers;
 
 /**
  * This class is responsible for running a performance test on connectors integrated with PRS.
@@ -17,7 +18,7 @@ public class PrsConnectorPerformanceTest extends SystemTestsBase {
 
     public static class PerformanceTestsRunner extends PrsConnectorSimulationBase {
         {
-            setUp(scenarioBuilder.injectOpen(CoreDsl.atOnceUsers(10))).protocols(httpProtocol);
+            setUp(scenarioBuilder.injectOpen(atOnceUsers(10))).protocols(httpProtocol);
         }
     }
 }

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorPerformanceTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorPerformanceTest.java
@@ -15,7 +15,7 @@ public class PrsConnectorPerformanceTest extends SystemTestsBase {
         runGatling(PerformanceTestsRunner.class);
     }
 
-    public static class PerformanceTestsRunner extends Runner {
+    public static class PerformanceTestsRunner extends PrsConnectorSimulationBase {
         {
             setUp(scenarioBuilder.injectOpen(CoreDsl.atOnceUsers(10))).protocols(httpProtocol);
         }

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorSimulationBase.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorSimulationBase.java
@@ -2,10 +2,8 @@ package net.catenax.prs.systemtest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.gatling.javaapi.core.CoreDsl;
 import io.gatling.javaapi.core.ScenarioBuilder;
 import io.gatling.javaapi.core.Simulation;
-import io.gatling.javaapi.http.HttpDsl;
 import io.gatling.javaapi.http.HttpProtocolBuilder;
 import net.catenax.prs.connector.requests.PartsTreeByObjectIdRequest;
 import net.catenax.prs.connector.requests.PartsTreeRequest;
@@ -14,10 +12,12 @@ import net.catenax.prs.dtos.PartsTreeView;
 import java.time.Duration;
 
 import static io.gatling.javaapi.core.CoreDsl.StringBody;
+import static io.gatling.javaapi.core.CoreDsl.bodyString;
 import static io.gatling.javaapi.core.CoreDsl.doWhileDuring;
 import static io.gatling.javaapi.core.CoreDsl.exec;
 import static io.gatling.javaapi.core.CoreDsl.scenario;
 import static io.gatling.javaapi.http.HttpDsl.http;
+import static io.gatling.javaapi.http.HttpDsl.status;
 
 public class PrsConnectorSimulationBase extends Simulation {
 
@@ -39,7 +39,7 @@ public class PrsConnectorSimulationBase extends Simulation {
                             http("Trigger partsTree request")
                                     .post("/retrievePartsTree")
                                     .body(StringBody(getSerializedPartsTreeRequest()))
-                                    .check(HttpDsl.status().is(200)).check(CoreDsl.bodyString().saveAs("requestId"))
+                                    .check(status().is(200)).check(bodyString().saveAs("requestId"))
                     )
                     // Call status endpoint every second, till it gives a 200 status code.
                     .exec(session -> session.set("status", -1))
@@ -47,7 +47,7 @@ public class PrsConnectorSimulationBase extends Simulation {
                             doWhileDuring(session -> session.getInt("status") != 200, Duration.ofSeconds(12))
                                     .on(exec(http("Get status")
                                                     .get(session -> String.format("/datarequest/%s/state", session.getString("requestId")))
-                                                    .check(HttpDsl.status().saveAs("status")))
+                                                    .check(status().saveAs("status")))
                                             .pause(Duration.ofSeconds(1)))));
 
     protected String getSerializedPartsTreeRequest() {

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorSimulationBase.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorSimulationBase.java
@@ -19,7 +19,7 @@ import static io.gatling.javaapi.core.CoreDsl.exec;
 import static io.gatling.javaapi.core.CoreDsl.scenario;
 import static io.gatling.javaapi.http.HttpDsl.http;
 
-public class Runner extends Simulation {
+public class PrsConnectorSimulationBase extends Simulation {
 
     private static final String connectorUri = System.getenv()
             .getOrDefault("ConnectorURI", "https://catenaxdev001akssrv.germanywestcentral.cloudapp.azure.com/prs-connector-consumer/api/v0.1");

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
@@ -1,8 +1,9 @@
 package net.catenax.prs.systemtest;
 
-import io.gatling.javaapi.core.CoreDsl;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import static io.gatling.javaapi.core.CoreDsl.incrementUsersPerSec;
 
 /**
  * This class is responsible for running stress tests on connectors integrated with PRS.
@@ -28,7 +29,7 @@ public class PrsConnectorStressTest extends SystemTestsBase {
             // each level lasting 10 seconds
             // triggers part tree request 1000 times during all levels and 800 during ramps
             setUp(scenarioBuilder.injectOpen(
-                    CoreDsl.incrementUsersPerSec(5)
+                    incrementUsersPerSec(5)
                             .times(5)
                             .eachLevelLasting(10)
                             .separatedByRampsLasting(10)

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
@@ -14,13 +14,12 @@ public class PrsConnectorStressTest extends SystemTestsBase {
         runGatling(StressTestsRunner.class);
     }
 
-    static class StressTestsRunner extends Runner {
+    public static class StressTestsRunner extends Runner {
         {
             setUp(scenarioBuilder.injectOpen(
                     CoreDsl.incrementUsersPerSec(5)
                             .times(5)
                             .eachLevelLasting(10)
-                            .separatedByRampsLasting(10)
                             .startingFrom(10))).protocols(httpProtocol);
         }
     }

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
@@ -18,6 +18,10 @@ public class PrsConnectorStressTest extends SystemTestsBase {
     public static class StressTestsRunner extends Runner {
 
         {
+            this.vehicleOneId = "CAXSWPFTJQEVZNZZ";
+            this.vehicleObjectId = "OXCNTJT4D6AWSGAK3";
+            this.depth = 5;
+
             // generate an open workload injection profile
             // with levels of 10, 15, 20, 25 and 30 arriving users per second
             // separated by linear ramps lasting 10 seconds
@@ -29,11 +33,6 @@ public class PrsConnectorStressTest extends SystemTestsBase {
                             .eachLevelLasting(10)
                             .separatedByRampsLasting(10)
                             .startingFrom(10))).protocols(httpProtocol);
-        }
-
-        @Override
-        protected String getSerializedPartsTreeRequest(int depth, String vehicleObjectId, String vehicleOneId) {
-            return super.getSerializedPartsTreeRequest(6, "OXCNTJT4D6AWSGAK3", "CAXSWPFTJQEVZNZZ");
         }
     }
 }

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
@@ -33,7 +33,7 @@ public class PrsConnectorStressTest extends SystemTestsBase {
 
         @Override
         protected String getSerializedPartsTreeRequest(int depth, String vehicleObjectId, String vehicleOneId) {
-            return super.getSerializedPartsTreeRequest(5, "OXCNTJT4D6AWSGAK3", "CAXSWPFTJQEVZNZZ");
+            return super.getSerializedPartsTreeRequest(6, "OXCNTJT4D6AWSGAK3", "CAXSWPFTJQEVZNZZ");
         }
     }
 }

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
@@ -15,7 +15,7 @@ public class PrsConnectorStressTest extends SystemTestsBase {
         runGatling(StressTestsRunner.class);
     }
 
-    public static class StressTestsRunner extends Runner {
+    public static class StressTestsRunner extends PrsConnectorSimulationBase {
 
         {
             this.vehicleOneId = "CAXSWPFTJQEVZNZZ";

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
@@ -16,6 +16,10 @@ public class PrsConnectorStressTest extends SystemTestsBase {
 
     public static class StressTestsRunner extends Runner {
         {
+            // generate an open workload injection profile
+            // with levels of 10, 15, 20, 25 and 30 arriving users per second
+            // each level lasting 10 seconds
+            // triggers part tree request 1000 times
             setUp(scenarioBuilder.injectOpen(
                     CoreDsl.incrementUsersPerSec(5)
                             .times(5)

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
@@ -18,12 +18,14 @@ public class PrsConnectorStressTest extends SystemTestsBase {
         {
             // generate an open workload injection profile
             // with levels of 10, 15, 20, 25 and 30 arriving users per second
+            // separated by linear ramps lasting 10 seconds
             // each level lasting 10 seconds
-            // triggers part tree request 1000 times
+            // triggers part tree request 1000 times during all levels and 800 during ramps
             setUp(scenarioBuilder.injectOpen(
                     CoreDsl.incrementUsersPerSec(5)
                             .times(5)
                             .eachLevelLasting(10)
+                            .separatedByRampsLasting(10)
                             .startingFrom(10))).protocols(httpProtocol);
         }
     }

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
@@ -16,9 +16,6 @@ public class PrsConnectorStressTest extends SystemTestsBase {
     }
 
     public static class StressTestsRunner extends Runner {
-        public StressTestsRunner() {
-            super(5, "OXCNTJT4D6AWSGAK3", "CAXSWPFTJQEVZNZZ");
-        }
 
         {
             // generate an open workload injection profile
@@ -32,6 +29,11 @@ public class PrsConnectorStressTest extends SystemTestsBase {
                             .eachLevelLasting(10)
                             .separatedByRampsLasting(10)
                             .startingFrom(10))).protocols(httpProtocol);
+        }
+
+        @Override
+        protected String getSerializedPartsTreeRequest(int depth, String vehicleObjectId, String vehicleOneId) {
+            return super.getSerializedPartsTreeRequest(5, "OXCNTJT4D6AWSGAK3", "CAXSWPFTJQEVZNZZ");
         }
     }
 }

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
@@ -9,12 +9,17 @@ import org.junit.jupiter.api.Test;
  */
 @Tag("StressTests")
 public class PrsConnectorStressTest extends SystemTestsBase {
+    private static final int DEPTH = 5;
     @Test
     public void test() {
         runGatling(StressTestsRunner.class);
     }
 
     public static class StressTestsRunner extends Runner {
+        public StressTestsRunner() {
+            super(DEPTH);
+        }
+
         {
             // generate an open workload injection profile
             // with levels of 10, 15, 20, 25 and 30 arriving users per second
@@ -29,5 +34,4 @@ public class PrsConnectorStressTest extends SystemTestsBase {
                             .startingFrom(10))).protocols(httpProtocol);
         }
     }
-
 }

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
@@ -17,7 +17,7 @@ public class PrsConnectorStressTest extends SystemTestsBase {
 
     public static class StressTestsRunner extends Runner {
         public StressTestsRunner() {
-            super(5, "ZHMFXG5YELKUNLZ0K", "CAXSWPFTJQEVZNZZ");
+            super(5, "OXCNTJT4D6AWSGAK3", "CAXSWPFTJQEVZNZZ");
         }
 
         {

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
  */
 @Tag("StressTests")
 public class PrsConnectorStressTest extends SystemTestsBase {
-    private static final int DEPTH = 5;
+
     @Test
     public void test() {
         runGatling(StressTestsRunner.class);
@@ -17,7 +17,7 @@ public class PrsConnectorStressTest extends SystemTestsBase {
 
     public static class StressTestsRunner extends Runner {
         public StressTestsRunner() {
-            super(DEPTH);
+            super(5, "ZHMFXG5YELKUNLZ0K", "CAXSWPFTJQEVZNZZ");
         }
 
         {

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/PrsConnectorStressTest.java
@@ -1,0 +1,28 @@
+package net.catenax.prs.systemtest;
+
+import io.gatling.javaapi.core.CoreDsl;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This class is responsible for running stress tests on connectors integrated with PRS.
+ */
+@Tag("StressTests")
+public class PrsConnectorStressTest extends SystemTestsBase {
+    @Test
+    public void test() {
+        runGatling(StressTestsRunner.class);
+    }
+
+    static class StressTestsRunner extends Runner {
+        {
+            setUp(scenarioBuilder.injectOpen(
+                    CoreDsl.incrementUsersPerSec(5)
+                            .times(5)
+                            .eachLevelLasting(10)
+                            .separatedByRampsLasting(10)
+                            .startingFrom(10))).protocols(httpProtocol);
+        }
+    }
+
+}

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/Runner.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/Runner.java
@@ -74,7 +74,6 @@ public class Runner extends Simulation {
         try {
             return MAPPER.writeValueAsString(params);
         } catch (JsonProcessingException e) {
-            e.printStackTrace();
             throw new RuntimeException("Exception serializing parts tree request", e);
         }
     }

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/Runner.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/Runner.java
@@ -22,22 +22,6 @@ public class Runner extends Simulation {
     private static final int DEPTH = 2;
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private String vehicleOneId;
-    private String vehicleObjectId;
-    private int depth;
-
-    public Runner(int depth, String vehicleObjectId, String vehicleOneId) {
-        this.depth = depth;
-        this.vehicleObjectId = vehicleObjectId;
-        this.vehicleOneId = vehicleOneId;
-    }
-
-    public Runner() {
-        this.vehicleObjectId = VEHICLE_OBJECTID;
-        this.vehicleOneId = VEHICLE_ONEID;
-        this.depth = DEPTH;
-    }
-
     protected HttpProtocolBuilder httpProtocol = HttpDsl.http.baseUrl(connectorUri)
             .acceptHeader("*/*").contentTypeHeader("application/json");
     // Trigger a get parts tree request. Then call status endpoint every second till it returns 200.
@@ -47,7 +31,7 @@ public class Runner extends Simulation {
             .on(CoreDsl.exec(
                             HttpDsl.http("Trigger partsTree request")
                                     .post("/retrievePartsTree")
-                                    .body(CoreDsl.StringBody(getSerializedPartsTreeRequest()))
+                                    .body(CoreDsl.StringBody(getSerializedPartsTreeRequest(DEPTH, VEHICLE_OBJECTID, VEHICLE_ONEID)))
                                     .check(HttpDsl.status().is(200)).check(CoreDsl.bodyString().saveAs("requestId"))
                     )
                     // Call status endpoint every second, till it gives a 200 status code.
@@ -59,7 +43,7 @@ public class Runner extends Simulation {
                                                     .check(HttpDsl.status().saveAs("status")))
                                             .pause(Duration.ofSeconds(1)))));
 
-    private String getSerializedPartsTreeRequest() {
+    protected String getSerializedPartsTreeRequest(int depth, String vehicleObjectId, String vehicleOneId) {
         var params = PartsTreeRequest.builder()
                 .byObjectIdRequest(
                         PartsTreeByObjectIdRequest.builder()

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/Runner.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/Runner.java
@@ -23,21 +23,22 @@ public class Runner extends Simulation {
 
     private static final String connectorUri = System.getenv()
             .getOrDefault("ConnectorURI", "https://catenaxdev001akssrv.germanywestcentral.cloudapp.azure.com/prs-connector-consumer/api/v0.1");
-    private static final String VEHICLE_ONEID = "CAXSWPFTJQEVZNZZ";
-    private static final String VEHICLE_OBJECTID = "UVVZI9PKX5D37RFUB";
-    private static final int DEPTH = 2;
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     protected HttpProtocolBuilder httpProtocol = http.baseUrl(connectorUri)
             .acceptHeader("*/*").contentTypeHeader("application/json");
     // Trigger a get parts tree request. Then call status endpoint every second till it returns 200.
 
+    protected String vehicleOneId = "CAXSWPFTJQEVZNZZ";
+    protected String vehicleObjectId = "UVVZI9PKX5D37RFUB";
+    protected int depth = 2;
+
     protected ScenarioBuilder scenarioBuilder = scenario("Trigger Get parts tree for a part.")
             .repeat(1)
             .on(exec(
                             http("Trigger partsTree request")
                                     .post("/retrievePartsTree")
-                                    .body(StringBody(getSerializedPartsTreeRequest(DEPTH, VEHICLE_OBJECTID, VEHICLE_ONEID)))
+                                    .body(StringBody(getSerializedPartsTreeRequest()))
                                     .check(HttpDsl.status().is(200)).check(CoreDsl.bodyString().saveAs("requestId"))
                     )
                     // Call status endpoint every second, till it gives a 200 status code.
@@ -49,7 +50,7 @@ public class Runner extends Simulation {
                                                     .check(HttpDsl.status().saveAs("status")))
                                             .pause(Duration.ofSeconds(1)))));
 
-    protected String getSerializedPartsTreeRequest(int depth, String vehicleObjectId, String vehicleOneId) {
+    protected String getSerializedPartsTreeRequest() {
         var params = PartsTreeRequest.builder()
                 .byObjectIdRequest(
                         PartsTreeByObjectIdRequest.builder()

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/Runner.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/Runner.java
@@ -43,7 +43,6 @@ public class Runner extends Simulation {
     // Trigger a get parts tree request. Then call status endpoint every second till it returns 200.
 
     protected ScenarioBuilder scenarioBuilder = CoreDsl.scenario("Trigger Get parts tree for a part.")
-            // TODO: Decide right configurations (how many repeat, and how many users at once)
             .repeat(1)
             .on(CoreDsl.exec(
                             HttpDsl.http("Trigger partsTree request")

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/Runner.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/Runner.java
@@ -22,11 +22,11 @@ public class Runner extends Simulation {
     private static final int DEPTH_VALUE = 2;
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    HttpProtocolBuilder httpProtocol = HttpDsl.http.baseUrl(connectorUri)
+    protected HttpProtocolBuilder httpProtocol = HttpDsl.http.baseUrl(connectorUri)
             .acceptHeader("*/*").contentTypeHeader("application/json");
 
     // Trigger a get parts tree request. Then call status endpoint every second till it returns 200.
-    ScenarioBuilder scenarioBuilder = CoreDsl.scenario("Trigger Get parts tree for a part.")
+    protected ScenarioBuilder scenarioBuilder = CoreDsl.scenario("Trigger Get parts tree for a part.")
             // TODO: Decide right configurations (how many repeat, and how many users at once)
             .repeat(1)
             .on(CoreDsl.exec(

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/Runner.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/Runner.java
@@ -1,0 +1,65 @@
+package net.catenax.prs.systemtest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gatling.javaapi.core.CoreDsl;
+import io.gatling.javaapi.core.ScenarioBuilder;
+import io.gatling.javaapi.core.Simulation;
+import io.gatling.javaapi.http.HttpDsl;
+import io.gatling.javaapi.http.HttpProtocolBuilder;
+import net.catenax.prs.connector.requests.PartsTreeByObjectIdRequest;
+import net.catenax.prs.connector.requests.PartsTreeRequest;
+import net.catenax.prs.dtos.PartsTreeView;
+
+import java.time.Duration;
+
+public class Runner extends Simulation {
+
+    private static final String connectorUri = System.getenv()
+            .getOrDefault("ConnectorURI", "https://catenaxdev001akssrv.germanywestcentral.cloudapp.azure.com/prs-connector-consumer/api/v0.1");
+    private static final String VEHICLE_ONEID = "CAXSWPFTJQEVZNZZ";
+    private static final String VEHICLE_OBJECTID = "UVVZI9PKX5D37RFUB";
+    private static final int DEPTH_VALUE = 2;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    HttpProtocolBuilder httpProtocol = HttpDsl.http.baseUrl(connectorUri)
+            .acceptHeader("*/*").contentTypeHeader("application/json");
+
+    // Trigger a get parts tree request. Then call status endpoint every second till it returns 200.
+    ScenarioBuilder scenarioBuilder = CoreDsl.scenario("Trigger Get parts tree for a part.")
+            // TODO: Decide right configurations (how many repeat, and how many users at once)
+            .repeat(1)
+            .on(CoreDsl.exec(
+                            HttpDsl.http("Trigger partsTree request")
+                                    .post("/retrievePartsTree")
+                                    .body(CoreDsl.StringBody(getSerializedPartsTreeRequest()))
+                                    .check(HttpDsl.status().is(200)).check(CoreDsl.bodyString().saveAs("requestId"))
+                    )
+                    // Call status endpoint every second, till it gives a 200 status code.
+                    .exec(session -> session.set("status", -1))
+                    .group("waitForCompletion").on(
+                            CoreDsl.doWhileDuring(session -> session.getInt("status") != 200, Duration.ofSeconds(12))
+                                    .on(CoreDsl.exec(HttpDsl.http("Get status")
+                                                    .get(session -> String.format("/datarequest/%s/state", session.getString("requestId")))
+                                                    .check(HttpDsl.status().saveAs("status")))
+                                            .pause(Duration.ofSeconds(1)))));
+
+    private static String getSerializedPartsTreeRequest() {
+        var params = PartsTreeRequest.builder()
+                .byObjectIdRequest(
+                        PartsTreeByObjectIdRequest.builder()
+                                .oneIDManufacturer(VEHICLE_ONEID)
+                                .objectIDManufacturer(VEHICLE_OBJECTID)
+                                .view(PartsTreeView.AS_BUILT.name())
+                                .aspect(PrsConnectorStressTest.ASPECT_MATERIAL)
+                                .depth(DEPTH_VALUE)
+                                .build()).build();
+
+        try {
+            return MAPPER.writeValueAsString(params);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Exception serializing parts tree request", e);
+        }
+    }
+}

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/Runner.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/systemtest/Runner.java
@@ -19,14 +19,23 @@ public class Runner extends Simulation {
             .getOrDefault("ConnectorURI", "https://catenaxdev001akssrv.germanywestcentral.cloudapp.azure.com/prs-connector-consumer/api/v0.1");
     private static final String VEHICLE_ONEID = "CAXSWPFTJQEVZNZZ";
     private static final String VEHICLE_OBJECTID = "UVVZI9PKX5D37RFUB";
+    private static final int DEPTH = 2;
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private int depth = 2;
 
-    public Runner(int depth) {
+    private String vehicleOneId;
+    private String vehicleObjectId;
+    private int depth;
+
+    public Runner(int depth, String vehicleObjectId, String vehicleOneId) {
         this.depth = depth;
+        this.vehicleObjectId = vehicleObjectId;
+        this.vehicleOneId = vehicleOneId;
     }
 
     public Runner() {
+        this.vehicleObjectId = VEHICLE_OBJECTID;
+        this.vehicleOneId = VEHICLE_ONEID;
+        this.depth = DEPTH;
     }
 
     protected HttpProtocolBuilder httpProtocol = HttpDsl.http.baseUrl(connectorUri)
@@ -39,7 +48,7 @@ public class Runner extends Simulation {
             .on(CoreDsl.exec(
                             HttpDsl.http("Trigger partsTree request")
                                     .post("/retrievePartsTree")
-                                    .body(CoreDsl.StringBody(getSerializedPartsTreeRequest(depth)))
+                                    .body(CoreDsl.StringBody(getSerializedPartsTreeRequest()))
                                     .check(HttpDsl.status().is(200)).check(CoreDsl.bodyString().saveAs("requestId"))
                     )
                     // Call status endpoint every second, till it gives a 200 status code.
@@ -51,12 +60,12 @@ public class Runner extends Simulation {
                                                     .check(HttpDsl.status().saveAs("status")))
                                             .pause(Duration.ofSeconds(1)))));
 
-    private static String getSerializedPartsTreeRequest(int depth) {
+    private String getSerializedPartsTreeRequest() {
         var params = PartsTreeRequest.builder()
                 .byObjectIdRequest(
                         PartsTreeByObjectIdRequest.builder()
-                                .oneIDManufacturer(VEHICLE_ONEID)
-                                .objectIDManufacturer(VEHICLE_OBJECTID)
+                                .oneIDManufacturer(vehicleOneId)
+                                .objectIDManufacturer(vehicleObjectId)
                                 .view(PartsTreeView.AS_BUILT.name())
                                 .aspect(PrsConnectorStressTest.ASPECT_MATERIAL)
                                 .depth(depth)


### PR DESCRIPTION
Add stress test with a scenario that increments by 5 the rate of users per second 5 times.
Extend dataspace-partition.json with 2 additional partitions according to: https://confluence.catena-x.net/pages/viewpage.action?spaceKey=ARTI&title=MTPDC+Demo+Deployment

![Screenshot 2021-12-03 at 12 03 09](https://user-images.githubusercontent.com/4217554/144592022-919e417d-dcac-4abb-85e9-83af42dfda7e.png)

Stress tests run from local machine:

![Screenshot 2021-12-02 at 16 45 36](https://user-images.githubusercontent.com/4217554/144454927-85dc3a93-739f-402f-9c17-d36e30c54705.png)
![Screenshot 2021-12-02 at 16 45 42](https://user-images.githubusercontent.com/4217554/144455076-593d8293-07e9-4402-9173-b457c419f658.png)




