### PR TITLE
Feature/a1 mtdc@203 prs api request object validation

### DIFF
--- a/coreservices/partsrelationshipservice/api/prs-v0.1.yaml
+++ b/coreservices/partsrelationshipservice/api/prs-v0.1.yaml
@@ -17,6 +17,8 @@ paths:
         required: true
         schema:
           type: string
+          maxLength: 10000
+          minLength: 1
       - description: "Unique identifier of a single, unique physical (sub)component/part/batch,\
           \ given by its manufacturer"
         in: path
@@ -24,6 +26,8 @@ paths:
         required: true
         schema:
           type: string
+          maxLength: 10000
+          minLength: 1
       - description: PartsTree View to retrieve
         in: query
         name: view
@@ -41,6 +45,9 @@ paths:
         required: false
         schema:
           type: string
+          maxLength: 10000
+          minLength: 1
+          pattern: ^(?!\s*$).+
       - description: "Max depth of the returned tree, if empty max depth is returned"
         in: query
         name: depth
@@ -75,6 +82,8 @@ paths:
         required: true
         schema:
           type: string
+          maxLength: 17
+          minLength: 17
       - description: PartsTree View to retrieve
         in: query
         name: view
@@ -92,6 +101,9 @@ paths:
         required: false
         schema:
           type: string
+          maxLength: 10000
+          minLength: 1
+          pattern: ^(?!\s*$).+
       - description: "Max depth of the returned tree, if empty max depth is returned"
         in: query
         name: depth

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/integrationtest/GetPartsTreeByObjectIdIntegrationTests.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/integrationtest/GetPartsTreeByObjectIdIntegrationTests.java
@@ -87,41 +87,6 @@ public class GetPartsTreeByObjectIdIntegrationTests extends PrsIntegrationTestsB
     }
 
     @Test
-    public void getPartsTreeByObjectId_noView_returns400() {
-        var response =
-               given()
-                   .pathParam(ONE_ID_MANUFACTURER, PART_ONE_ID)
-                   .pathParam(OBJECT_ID_MANUFACTURER, PART_OBJECT_ID)
-               .when()
-                   .get(PATH)
-               .then()
-                   .assertThat()
-                   .statusCode(HttpStatus.BAD_REQUEST.value())
-                   .extract().asString();
-
-        assertThatJson(response)
-                .isEqualTo(expected.invalidArgument(List.of(VIEW +":"+ ApiErrorsConstants.PARTS_TREE_VIEW_NOT_NULL)));
-    }
-
-    @Test
-    public void getPartsTreeByObjectId_invalidView_returns400() {
-        var response =
-               given()
-                       .pathParam(ONE_ID_MANUFACTURER, PART_ONE_ID)
-                       .pathParam(OBJECT_ID_MANUFACTURER, PART_OBJECT_ID)
-                       .queryParam(VIEW, "not-valid")
-               .when()
-                       .get(PATH)
-               .then()
-                       .assertThat()
-                       .statusCode(HttpStatus.BAD_REQUEST.value())
-                       .extract().asString();
-
-        assertThatJson(response)
-                .isEqualTo(expected.invalidArgument(List.of(VIEW +":"+ ApiErrorsConstants.PARTS_TREE_VIEW_MUST_MATCH_ENUM)));
-    }
-
-    @Test
     public void getPartsTreeByObjectId_exceedMaxDepth_returns400() {
         var maxDepth = configuration.getPartsTreeMaxDepth();
         var response =
@@ -139,26 +104,6 @@ public class GetPartsTreeByObjectIdIntegrationTests extends PrsIntegrationTestsB
 
         assertThatJson(response)
                 .isEqualTo(expected.invalidMaxDepth(List.of(MessageFormat.format(ApiErrorsConstants.PARTS_TREE_MAX_DEPTH, maxDepth))));
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {0, -1, Integer.MIN_VALUE})
-    public void getPartsTreeByObjectId_zeroOrNegativeDepth_returns400(int depth) {
-        var response =
-                given()
-                        .pathParam(ONE_ID_MANUFACTURER, PART_ONE_ID)
-                        .pathParam(OBJECT_ID_MANUFACTURER, PART_OBJECT_ID)
-                        .queryParam(VIEW, AS_MAINTAINED)
-                        .queryParam(DEPTH, depth)
-                .when()
-                        .get(PATH)
-                .then()
-                        .assertThat()
-                        .statusCode(HttpStatus.BAD_REQUEST.value())
-                        .extract().asString();
-
-        assertThatJson(response)
-                .isEqualTo(expected.invalidArgument(List.of(DEPTH +":"+ ApiErrorsConstants.PARTS_TREE_MIN_DEPTH)));
     }
 
     @ParameterizedTest

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/integrationtest/GetPartsTreeByObjectIdIntegrationTests.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/integrationtest/GetPartsTreeByObjectIdIntegrationTests.java
@@ -87,6 +87,23 @@ public class GetPartsTreeByObjectIdIntegrationTests extends PrsIntegrationTestsB
     }
 
     @Test
+    public void getPartsTreeByObjectId_noView_returns400() {
+        var response =
+               given()
+                   .pathParam(ONE_ID_MANUFACTURER, PART_ONE_ID)
+                   .pathParam(OBJECT_ID_MANUFACTURER, PART_OBJECT_ID)
+               .when()
+                   .get(PATH)
+               .then()
+                   .assertThat()
+                   .statusCode(HttpStatus.BAD_REQUEST.value())
+                   .extract().asString();
+
+        assertThatJson(response)
+                .isEqualTo(expected.invalidArgument(List.of(VIEW +":"+ ApiErrorsConstants.PARTS_TREE_VIEW_NOT_NULL)));
+    }
+
+    @Test
     public void getPartsTreeByObjectId_exceedMaxDepth_returns400() {
         var maxDepth = configuration.getPartsTreeMaxDepth();
         var response =

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/integrationtest/GetPartsTreeByVinIntegrationTests.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/integrationtest/GetPartsTreeByVinIntegrationTests.java
@@ -68,6 +68,22 @@ public class GetPartsTreeByVinIntegrationTests extends PrsIntegrationTestsBase {
     }
 
     @Test
+    public void getPartsTreeByVin_noView_returns400() {
+        var response =
+                given()
+                    .pathParam(VIN, SAMPLE_VIN)
+                .when()
+                    .get(PATH)
+                .then()
+                    .assertThat()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                        .extract().asString();
+
+        assertThatJson(response)
+                .isEqualTo(expected.invalidArgument(List.of(VIEW +":"+ ApiErrorsConstants.PARTS_TREE_VIEW_NOT_NULL)));
+    }
+    
+    @Test
     public void getPartsTreeByVin_exceedMaxDepth_returns400() {
         var maxDepth = configuration.getPartsTreeMaxDepth();
         var response =

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/integrationtest/GetPartsTreeByVinIntegrationTests.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/integrationtest/GetPartsTreeByVinIntegrationTests.java
@@ -70,57 +70,6 @@ public class GetPartsTreeByVinIntegrationTests extends PrsIntegrationTestsBase {
     }
 
     @Test
-    public void getPartsTreeByVin_blankVin_returns400() {
-        var response =
-                given()
-                        .pathParam(VIN, "   ")
-                        .queryParam(VIEW, AS_MAINTAINED)
-                .when()
-                        .get(PATH)
-                .then()
-                        .assertThat()
-                        .statusCode(HttpStatus.BAD_REQUEST.value())
-                        .extract().asString();
-
-        assertThatJson(response)
-                .when(IGNORING_ARRAY_ORDER)
-                .isEqualTo(expected.invalidArgument(List.of(VIN +":must not be blank", VIN +":size must be between "+VIN_FIELD_LENGTH+" and "+VIN_FIELD_LENGTH)));
-    }
-
-    @Test
-    public void getPartsTreeByVin_noView_returns400() {
-        var response =
-                given()
-                    .pathParam(VIN, SAMPLE_VIN)
-                .when()
-                    .get(PATH)
-                .then()
-                    .assertThat()
-                    .statusCode(HttpStatus.BAD_REQUEST.value())
-                        .extract().asString();
-
-        assertThatJson(response)
-                .isEqualTo(expected.invalidArgument(List.of(VIEW +":"+ ApiErrorsConstants.PARTS_TREE_VIEW_NOT_NULL)));
-    }
-
-    @Test
-    public void getPartsTreeByVin_invalidView_returns400() {
-        var response =
-                given()
-                    .pathParam(VIN, SAMPLE_VIN)
-                    .queryParam(VIEW, "not-valid")
-                .when()
-                    .get(PATH)
-                .then()
-                    .assertThat()
-                    .statusCode(HttpStatus.BAD_REQUEST.value())
-                        .extract().asString();
-
-        assertThatJson(response)
-                .isEqualTo(expected.invalidArgument(List.of(VIEW +":"+ ApiErrorsConstants.PARTS_TREE_VIEW_MUST_MATCH_ENUM)));
-    }
-
-    @Test
     public void getPartsTreeByVin_exceedMaxDepth_returns400() {
         var maxDepth = configuration.getPartsTreeMaxDepth();
         var response =
@@ -137,25 +86,6 @@ public class GetPartsTreeByVinIntegrationTests extends PrsIntegrationTestsBase {
 
         assertThatJson(response)
                 .isEqualTo(expected.invalidMaxDepth(List.of(MessageFormat.format(ApiErrorsConstants.PARTS_TREE_MAX_DEPTH, maxDepth))));
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {0, -1, Integer.MIN_VALUE})
-    public void getPartsTreeByVin_zeroOrNegativeDepth_returns400(int depth) {
-        var response =
-                given()
-                        .pathParam(VIN, SAMPLE_VIN)
-                        .queryParam(VIEW, AS_MAINTAINED)
-                        .queryParam(DEPTH, depth)
-                .when()
-                        .get(PATH)
-                .then()
-                        .assertThat()
-                        .statusCode(HttpStatus.BAD_REQUEST.value())
-                        .extract().asString();
-
-        assertThatJson(response)
-                .isEqualTo(expected.invalidArgument(List.of(DEPTH +":"+ ApiErrorsConstants.PARTS_TREE_MIN_DEPTH)));
     }
 
     @Test

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/integrationtest/GetPartsTreeByVinIntegrationTests.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/integrationtest/GetPartsTreeByVinIntegrationTests.java
@@ -11,8 +11,6 @@ package net.catenax.prs.integrationtest;
 
 import net.catenax.prs.controllers.ApiErrorsConstants;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpStatus;
 
 import java.text.MessageFormat;
@@ -53,7 +51,7 @@ public class GetPartsTreeByVinIntegrationTests extends PrsIntegrationTestsBase {
 
     @Test
     public void getPartsTreeByVin_notExistingVIN_returns404() {
-        var notExistingVin = "PQTYHSPVXFGLFLCFM";
+        var notExistingVin = faker.lorem().characters(VIN_FIELD_LENGTH);
         var response =
                 given()
                     .pathParam(VIN, notExistingVin)

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/integrationtest/GetPartsTreeByVinIntegrationTests.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/integrationtest/GetPartsTreeByVinIntegrationTests.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static net.catenax.prs.dtos.PartsTreeView.AS_MAINTAINED;
+import static net.catenax.prs.dtos.ValidationConstants.VIN_FIELD_LENGTH;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 
@@ -52,7 +53,7 @@ public class GetPartsTreeByVinIntegrationTests extends PrsIntegrationTestsBase {
 
     @Test
     public void getPartsTreeByVin_notExistingVIN_returns404() {
-        var notExistingVin = "not-existing-vin";
+        var notExistingVin = "PQTYHSPVXFGLFLCFM";
         var response =
                 given()
                     .pathParam(VIN, notExistingVin)
@@ -82,7 +83,8 @@ public class GetPartsTreeByVinIntegrationTests extends PrsIntegrationTestsBase {
                         .extract().asString();
 
         assertThatJson(response)
-                .isEqualTo(expected.invalidArgument(List.of(VIN +":must not be blank")));
+                .when(IGNORING_ARRAY_ORDER)
+                .isEqualTo(expected.invalidArgument(List.of(VIN +":must not be blank", VIN +":size must be between "+VIN_FIELD_LENGTH+" and "+VIN_FIELD_LENGTH)));
     }
 
     @Test

--- a/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/integrationtest/PrsIntegrationTestsBase.java
+++ b/coreservices/partsrelationshipservice/integration-tests/src/test/java/net/catenax/prs/integrationtest/PrsIntegrationTestsBase.java
@@ -9,6 +9,7 @@
 //
 package net.catenax.prs.integrationtest;
 
+import com.github.javafaker.Faker;
 import io.restassured.RestAssured;
 import net.catenax.prs.PrsApplication;
 import net.catenax.prs.configuration.PrsConfiguration;
@@ -82,6 +83,8 @@ public class PrsIntegrationTestsBase {
      * Docker container image used to run Kafka Test Container.
      */
     private static final String KAFKA_TEST_CONTAINER_IMAGE = "confluentinc/cp-kafka:5.4.3";
+
+    protected static final Faker faker = new Faker();
 
     /**
      * The first partition number for a Kafka topic. Partition 0 always exists, regardless

--- a/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/controllers/ApiErrorsConstants.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/controllers/ApiErrorsConstants.java
@@ -25,4 +25,5 @@ public class ApiErrorsConstants {
     public static final String PARTS_TREE_MIN_DEPTH = "Depth should be at least 1.";
     public static final String PARTS_TREE_MAX_DEPTH = "Depth should not be more than {0}";
     public static final String VEHICLE_NOT_FOUND_BY_VIN = "Vehicle not found by VIN {0}";
+    public static final String NOT_BLANK = "Must not be blank.";
 }

--- a/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/requests/PartsTreeByObjectIdRequest.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/requests/PartsTreeByObjectIdRequest.java
@@ -15,8 +15,11 @@ import lombok.Value;
 import net.catenax.prs.controllers.PrsController;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
+import static net.catenax.prs.dtos.ValidationConstants.INPUT_FIELD_MAX_LENGTH;
+import static net.catenax.prs.dtos.ValidationConstants.INPUT_FIELD_MIN_LENGTH;
 
 /**
  * Parameter object for {@link PrsController#getPartsTree(PartsTreeByObjectIdRequest)} REST operation.
@@ -26,10 +29,12 @@ import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 public class PartsTreeByObjectIdRequest extends PartsTreeRequestBase {
 
     @NotBlank
+    @Size(min = INPUT_FIELD_MIN_LENGTH, max = INPUT_FIELD_MAX_LENGTH)
     @Parameter(description = "Readable ID of manufacturer including plant", in = PATH, required = true)
     String oneIDManufacturer;
 
     @NotBlank
+    @Size(min = INPUT_FIELD_MIN_LENGTH, max = INPUT_FIELD_MAX_LENGTH)
     @Parameter(description = "Unique identifier of a single, unique physical (sub)component/part/batch, given by its manufacturer", in = PATH, required = true)
     String objectIDManufacturer;
 

--- a/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/requests/PartsTreeByVinRequest.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/requests/PartsTreeByVinRequest.java
@@ -15,8 +15,10 @@ import lombok.Value;
 import net.catenax.prs.controllers.PrsController;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
+import static net.catenax.prs.dtos.ValidationConstants.VIN_FIELD_LENGTH;
 
 /**
  * Parameter object for {@link PrsController#getPartsTree(PartsTreeByVinRequest)} REST operation.
@@ -25,6 +27,7 @@ import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 @SuppressWarnings({"PMD.CommentRequired"})
 public class PartsTreeByVinRequest extends PartsTreeRequestBase {
     @NotBlank
+    @Size(min = VIN_FIELD_LENGTH, max = VIN_FIELD_LENGTH)
     @Parameter(description = "Vehicle Identification Number", in = PATH, required = true)
     private String vin;
 

--- a/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/requests/PartsTreeRequestBase.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/requests/PartsTreeRequestBase.java
@@ -17,7 +17,7 @@ import net.catenax.prs.controllers.ApiErrorsConstants;
 import net.catenax.prs.dtos.PartsTreeView;
 
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import java.util.Optional;
@@ -32,7 +32,7 @@ import static net.catenax.prs.dtos.ValidationConstants.INPUT_FIELD_MIN_LENGTH;
 @RequiredArgsConstructor
 @SuppressWarnings({"PMD.CommentRequired", "PMD.AbstractClassWithoutAbstractMethod"})
 abstract class PartsTreeRequestBase {
-    @NotNull(message = ApiErrorsConstants.PARTS_TREE_VIEW_NOT_NULL)
+    @NotBlank(message = ApiErrorsConstants.PARTS_TREE_VIEW_NOT_NULL)
     @ValueOfEnum(enumClass = PartsTreeView.class, message = ApiErrorsConstants.PARTS_TREE_VIEW_MUST_MATCH_ENUM)
     @Parameter(description = "PartsTree View to retrieve", in = QUERY, required = true, schema = @Schema(implementation = PartsTreeView.class))
     protected final String view;

--- a/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/requests/PartsTreeRequestBase.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/main/java/net/catenax/prs/requests/PartsTreeRequestBase.java
@@ -18,9 +18,13 @@ import net.catenax.prs.dtos.PartsTreeView;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import java.util.Optional;
 
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY;
+import static net.catenax.prs.dtos.ValidationConstants.INPUT_FIELD_MAX_LENGTH;
+import static net.catenax.prs.dtos.ValidationConstants.INPUT_FIELD_MIN_LENGTH;
 
 /**
  * Base for {@code getPartsTreeBy*} parameter objects.
@@ -33,6 +37,8 @@ abstract class PartsTreeRequestBase {
     @Parameter(description = "PartsTree View to retrieve", in = QUERY, required = true, schema = @Schema(implementation = PartsTreeView.class))
     protected final String view;
 
+    @Pattern(regexp = "^(?!\\s*$).+", message = ApiErrorsConstants.NOT_BLANK)
+    @Size(min = INPUT_FIELD_MIN_LENGTH, max = INPUT_FIELD_MAX_LENGTH)
     @Parameter(description = "Aspect information to add to the returned tree", in = QUERY, example = "CE", schema = @Schema(implementation = String.class))
     protected final String aspect;
 

--- a/coreservices/partsrelationshipservice/prs-api/src/test/java/net/catenax/prs/requests/PartsTreeByObjectIdRequestTests.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/test/java/net/catenax/prs/requests/PartsTreeByObjectIdRequestTests.java
@@ -33,6 +33,15 @@ public class PartsTreeByObjectIdRequestTests extends RequestTestBase {
         return Stream.of(
                 args("Valid", identity(), null),
 
+                args("Invalid view", b -> b.view(faker.lorem().word()), "view"),
+                args("View not null", b -> b.view(null), "view"),
+                args("View not empty", b -> b.view(EMPTY), "view"),
+                args("View not blank", b -> b.view(faker.regexify(WHITESPACE_REGEX)), "view"),
+
+                args("Aspect not empty", b -> b.aspect(EMPTY), "aspect"),
+                args("Aspect not blank", b -> b.aspect(faker.regexify(WHITESPACE_REGEX)), "aspect"),
+
+                args("Depth min 1", b -> b.depth(faker.number().numberBetween(Integer.MIN_VALUE, 0)), "depth"),
                 args("oneIDManufacturer not null", b -> b.oneIDManufacturer(null), "oneIDManufacturer"),
                 args("oneIDManufacturer not empty", b -> b.oneIDManufacturer(EMPTY), "oneIDManufacturer"),
                 args("oneIDManufacturer not blank", b -> b.oneIDManufacturer(faker.regexify(WHITESPACE_REGEX)), "oneIDManufacturer"),

--- a/coreservices/partsrelationshipservice/prs-api/src/test/java/net/catenax/prs/requests/PartsTreeByObjectIdRequestTests.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/test/java/net/catenax/prs/requests/PartsTreeByObjectIdRequestTests.java
@@ -1,0 +1,55 @@
+package net.catenax.prs.requests;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
+import static java.util.function.UnaryOperator.identity;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PartsTreeByObjectIdRequestTests extends RequestTestBase {
+
+    PartsTreeByObjectIdRequest sut = generateRequest.byObjectId();
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("mutators")
+    public void validate(String testName, UnaryOperator<PartsTreeByObjectIdRequest.PartsTreeByObjectIdRequestBuilder> mutator, String expectedViolationPath) {
+        sut = mutator.apply(sut.toBuilder()).build();
+        //Act
+        var violations = validator.validate(sut);
+        //Assert
+        if (expectedViolationPath == null) {
+            assertThat(violations.isEmpty()).isTrue();
+        } else {
+            var violationPaths = violations.stream().map(v -> v.getPropertyPath().toString());
+            assertThat(violationPaths).contains(expectedViolationPath);
+        }
+    }
+
+    private static Stream<Arguments> mutators() {
+        return Stream.of(
+                args("Valid", identity(), null),
+
+                args("oneIDManufacturer not null", b -> b.oneIDManufacturer(null), "oneIDManufacturer"),
+                args("oneIDManufacturer not empty", b -> b.oneIDManufacturer(EMPTY), "oneIDManufacturer"),
+                args("oneIDManufacturer not blank", b -> b.oneIDManufacturer(faker.regexify(WHITESPACE_REGEX)), "oneIDManufacturer"),
+                args("oneIDManufacturer max 10000 [1]", b -> b.oneIDManufacturer(faker.lorem().characters(10001)), "oneIDManufacturer"),
+                args("oneIDManufacturer max 10000 [2]", b -> b.oneIDManufacturer(faker.lorem().characters(10001, 100000)), "oneIDManufacturer"),
+
+                args("objectIDManufacturer not null", b -> b.objectIDManufacturer(null), "objectIDManufacturer"),
+                args("objectIDManufacturer not empty", b -> b.objectIDManufacturer(EMPTY), "objectIDManufacturer"),
+                args("objectIDManufacturer not blank", b -> b.objectIDManufacturer(faker.regexify(WHITESPACE_REGEX)), "objectIDManufacturer"),
+                args("objectIDManufacturer max 10000 [1]", b -> b.objectIDManufacturer(faker.lorem().characters(10001)), "objectIDManufacturer"),
+                args("objectIDManufacturer max 10000 [2]", b -> b.objectIDManufacturer(faker.lorem().characters(10001, 100000)), "objectIDManufacturer")
+        );
+    }
+
+    private static Arguments args(String testName,
+                                  UnaryOperator<PartsTreeByObjectIdRequest.PartsTreeByObjectIdRequestBuilder> mutator,
+                                  String expectedViolationPath) {
+        return Arguments.of(testName, mutator, expectedViolationPath);
+    }
+}

--- a/coreservices/partsrelationshipservice/prs-api/src/test/java/net/catenax/prs/requests/PartsTreeByVinRequestTests.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/test/java/net/catenax/prs/requests/PartsTreeByVinRequestTests.java
@@ -41,13 +41,16 @@ public class PartsTreeByVinRequestTests extends RequestTestBase {
                 args("Aspect not empty", b -> b.aspect(EMPTY), "aspect"),
                 args("Aspect not blank", b -> b.aspect(faker.regexify(WHITESPACE_REGEX)), "aspect"),
 
-                args("Depth min 1", b -> b.depth(faker.number().numberBetween(Integer.MIN_VALUE, 0)), "depth"),
+                args("Depth min 1 [1]", b -> b.depth(faker.number().numberBetween(Integer.MIN_VALUE, 0)), "depth"),
+                args("Depth min 1 [2]", b -> b.depth(0), "depth"),
 
                 args("Vin not null", b -> b.vin(null), "vin"),
                 args("Vin not empty", b -> b.vin(EMPTY), "vin"),
                 args("Vin not blank", b -> b.vin(faker.regexify(WHITESPACE_REGEX)), "vin"),
                 args("Vin must be size 17 [1]", b -> b.vin(faker.lorem().characters(1, 16)), "vin"),
-                args("Vin must be size 17 [2]", b -> b.vin(faker.lorem().characters(18, 100)), "vin")
+                args("Vin must be size 17 [2]", b -> b.vin(faker.lorem().characters(16)), "vin"),
+                args("Vin must be size 17 [3]", b -> b.vin(faker.lorem().characters(18, 100)), "vin"),
+                args("Vin must be size 17 [4]", b -> b.vin(faker.lorem().characters(18)), "vin")
         );
     }
 

--- a/coreservices/partsrelationshipservice/prs-api/src/test/java/net/catenax/prs/requests/PartsTreeByVinRequestTests.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/test/java/net/catenax/prs/requests/PartsTreeByVinRequestTests.java
@@ -1,0 +1,59 @@
+package net.catenax.prs.requests;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
+import static java.util.function.UnaryOperator.identity;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PartsTreeByVinRequestTests extends RequestTestBase {
+
+    PartsTreeByVinRequest sut = generateRequest.byVin();
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("mutators")
+    public void validate(String testName, UnaryOperator<PartsTreeByVinRequest.PartsTreeByVinRequestBuilder> mutator, String expectedViolationPath) {
+        sut = mutator.apply(sut.toBuilder()).build();
+        //Act
+        var violations = validator.validate(sut);
+        //Assert
+        if (expectedViolationPath == null) {
+            assertThat(violations.isEmpty()).isTrue();
+        } else {
+            var violationPaths = violations.stream().map(v -> v.getPropertyPath().toString());
+            assertThat(violationPaths).contains(expectedViolationPath);
+        }
+    }
+
+    private static Stream<Arguments> mutators() {
+        return Stream.of(
+                args("Valid", identity(), null),
+
+                args("Invalid view", b -> b.view(faker.lorem().word()), "view"),
+                args("View not null", b -> b.view(null), "view"),
+                args("View not empty", b -> b.view(EMPTY), "view"),
+                args("View not blank", b -> b.view(faker.regexify(WHITESPACE_REGEX)), "view"),
+
+                args("Aspect not empty", b -> b.aspect(EMPTY), "aspect"),
+                args("Aspect not blank", b -> b.aspect(faker.regexify(WHITESPACE_REGEX)), "aspect"),
+
+                args("Depth min 1", b -> b.depth(faker.number().numberBetween(Integer.MIN_VALUE, 0)), "depth"),
+
+                args("Vin not null", b -> b.vin(null), "vin"),
+                args("Vin not empty", b -> b.vin(EMPTY), "vin"),
+                args("Vin not blank", b -> b.vin(faker.regexify(WHITESPACE_REGEX)), "vin"),
+                args("Vin must be size 17 [1]", b -> b.vin(faker.lorem().characters(1, 16)), "vin"),
+                args("Vin must be size 17 [2]", b -> b.vin(faker.lorem().characters(18, 100)), "vin")
+        );
+    }
+
+    private static Arguments args(String testName,
+                                  UnaryOperator<PartsTreeByVinRequest.PartsTreeByVinRequestBuilder> mutator,
+                                  String expectedViolationPath) {
+        return Arguments.of(testName, mutator, expectedViolationPath);
+    }
+}

--- a/coreservices/partsrelationshipservice/prs-api/src/test/java/net/catenax/prs/requests/RequestMother.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/test/java/net/catenax/prs/requests/RequestMother.java
@@ -5,6 +5,8 @@ import net.catenax.prs.dtos.PartsTreeView;
 import net.catenax.prs.entities.EntitiesMother;
 import net.catenax.prs.entities.PartIdEntityPart;
 
+import static net.catenax.prs.dtos.ValidationConstants.VIN_FIELD_LENGTH;
+
 public class RequestMother {
     /**
      * JavaFaker instance used to generate random data.
@@ -30,5 +32,9 @@ public class RequestMother {
 
     public PartsTreeByObjectIdRequest byObjectId() {
         return byObjectId(generate.partId());
+    }
+
+    public PartsTreeByVinRequest byVin() {
+        return byVin(faker.lorem().characters(VIN_FIELD_LENGTH));
     }
 }

--- a/coreservices/partsrelationshipservice/prs-api/src/test/java/net/catenax/prs/requests/RequestTestBase.java
+++ b/coreservices/partsrelationshipservice/prs-api/src/test/java/net/catenax/prs/requests/RequestTestBase.java
@@ -1,0 +1,28 @@
+package net.catenax.prs.requests;
+
+import com.github.javafaker.Faker;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+
+abstract class RequestTestBase {
+
+    protected static final Faker faker = new Faker();
+    /**
+     * Instance of {@link Validator} based on the default Jakarta Bean Validation.
+     */
+    protected static final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    /**
+     * This will match any of these whitespaces
+     * e.g. space (_), the tab (\t), the new line (\n) and the carriage return (\r).
+     */
+    protected static final String WHITESPACE_REGEX = "\\s";
+    /**
+     * Empty string as a constant.
+     */
+    protected static final String EMPTY = "";
+    /**
+     * Object Mother to generate prs api request data for testing.
+     */
+    protected RequestMother generateRequest = new RequestMother();
+}

--- a/coreservices/partsrelationshipservice/prs-common/src/main/java/net/catenax/prs/dtos/ValidationConstants.java
+++ b/coreservices/partsrelationshipservice/prs-common/src/main/java/net/catenax/prs/dtos/ValidationConstants.java
@@ -42,4 +42,8 @@ public class ValidationConstants {
      * Maximum number of aspects in update request.
      */
     public static final int ASPECT_UPDATE_LIST_MAX_SIZE = 1000;
+    /**
+     * VIN length for input field.
+     */
+    public static final int VIN_FIELD_LENGTH = 17;
 }


### PR DESCRIPTION
- Add length validation on prs-api request objects.
- Add test coverage.
- Remove overlapping ITs as now UTs cover such request validations.