### PR TITLE
Consumer watchdog with cancel process method

### DIFF
--- a/coreservices/partsrelationshipservice/connector/edc-patched-core/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessManager.java
+++ b/coreservices/partsrelationshipservice/connector/edc-patched-core/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessManager.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2020, 2020-2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.transfer;
+
+import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResponse;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferWaitStrategy;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+
+/**
+ * Manages data transfer processes.
+ * <br/>
+ * A data transfer processes transitions through a series of states, which allows the system to model both terminating and non-terminating (e.g. streaming) transfers. Transitions
+ * occur asynchronously, since long-running processes such as resource provisioning may need to be completed before transitioning to a subsequent state. The permissible state
+ * transitions are defined by {@link org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates}.
+ * <br/>
+ * The transfer manager performs continual iterations, which seek to advance the state of transfer processes, including recovery, in a FIFO state-based ordering.
+ * Each iteration will seek to transition a set number of processes for each state to avoid situations where an excessive number of processes in one state block progress of
+ * processes in other states.
+ * <br/>
+ * If no processes need to be transitioned, the transfer manager will wait according to the the defined {@link TransferWaitStrategy} before conducting the next iteration.
+ * A wait strategy may implement a backoff scheme.
+ */
+public interface TransferProcessManager {
+
+    /**
+     * Initiates a data transfer process on the consumer.
+     */
+    TransferInitiateResponse initiateConsumerRequest(DataRequest dataRequest);
+
+    /**
+     * Initiates a data transfer process on the provider.
+     */
+    TransferInitiateResponse initiateProviderRequest(DataRequest dataRequest);
+
+    /**
+     * Cancels a transfer process.
+     */
+    void cancelTransferProcess(String processId);
+}

--- a/coreservices/partsrelationshipservice/connector/edc-patched-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/coreservices/partsrelationshipservice/connector/edc-patched-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -1,0 +1,394 @@
+/*
+ *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.core.transfer;
+
+import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResponse;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessListener;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessObservable;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferWaitStrategy;
+import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowManager;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ProvisionManager;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceManifestGenerator;
+import org.eclipse.dataspaceconnector.spi.transfer.response.ResponseStatus;
+import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceManifest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.StatusCheckerRegistry;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+import static java.util.UUID.randomUUID;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess.Type.CONSUMER;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess.Type.PROVIDER;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.DEPROVISIONED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.DEPROVISIONING_REQ;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.INITIAL;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.PROVISIONED;
+
+public class TransferProcessManagerImpl extends TransferProcessObservable implements TransferProcessManager {
+    private final AtomicBoolean active = new AtomicBoolean();
+
+    private int batchSize = 5;
+    private TransferWaitStrategy waitStrategy = () -> 5000L;  // default wait five seconds
+    private ResourceManifestGenerator manifestGenerator;
+    private ProvisionManager provisionManager;
+    private TransferProcessStore transferProcessStore;
+    private RemoteMessageDispatcherRegistry dispatcherRegistry;
+    private DataFlowManager dataFlowManager;
+    private Monitor monitor;
+    private ExecutorService executor;
+    private StatusCheckerRegistry statusCheckerRegistry;
+
+    private TransferProcessManagerImpl() {
+
+    }
+
+    public void start(TransferProcessStore processStore) {
+        transferProcessStore = processStore;
+        active.set(true);
+        executor = Executors.newSingleThreadExecutor();
+        executor.submit(this::run);
+    }
+
+    public void stop() {
+        active.set(false);
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    @Override
+    public TransferInitiateResponse initiateConsumerRequest(DataRequest dataRequest) {
+        return initiateRequest(CONSUMER, dataRequest);
+    }
+
+    @Override
+    public TransferInitiateResponse initiateProviderRequest(DataRequest dataRequest) {
+        return initiateRequest(PROVIDER, dataRequest);
+    }
+
+    @Override
+    public void cancelTransferProcess(String processId) {
+        TransferProcess process = transferProcessStore.find(processId);
+        process.transitionError("Cancelled");
+        transferProcessStore.update(process);
+        invokeForEach(l -> l.error(process));
+    }
+
+    private TransferInitiateResponse initiateRequest(TransferProcess.Type type, DataRequest dataRequest) {
+        // make the request idempotent: if the process exists, return
+        var processId = transferProcessStore.processIdForTransferId(dataRequest.getId());
+        if (processId != null) {
+            return TransferInitiateResponse.Builder.newInstance().id(processId).status(ResponseStatus.OK).build();
+        }
+        var id = randomUUID().toString();
+        var process = TransferProcess.Builder.newInstance().id(id).dataRequest(dataRequest).type(type).build();
+        transferProcessStore.create(process);
+        invokeForEach(l -> l.created(process));
+        return TransferInitiateResponse.Builder.newInstance().id(process.getId()).status(ResponseStatus.OK).build();
+    }
+
+    private void run() {
+        while (active.get()) {
+            try {
+                int provisioning = provisionInitialProcesses();
+
+                // TODO check processes in provisioning state and timestamps for failed processes
+
+                int sent = sendOrProcessProvisionedRequests();
+
+                int provisioned = checkProvisioned();
+
+                int finished = checkCompleted();
+
+                int deprovisioning = checkDeprovisioningRequested();
+
+                int deprovisioned = checkDeprovisioned();
+
+                if (provisioning + provisioned + sent + finished + deprovisioning + deprovisioned == 0) {
+                    Thread.sleep(waitStrategy.waitForMillis());
+                }
+                waitStrategy.success();
+            } catch (Error e) {
+                throw e; // let the thread die and don't reschedule as the error is unrecoverable
+            } catch (InterruptedException e) {
+                Thread.interrupted();
+                active.set(false);
+                break;
+            } catch (Throwable e) {
+                monitor.severe("Error caught in transfer process manager", e);
+                try {
+                    Thread.sleep(waitStrategy.retryInMillis());
+                } catch (InterruptedException e2) {
+                    Thread.interrupted();
+                    active.set(false);
+                    break;
+                }
+            }
+        }
+    }
+
+
+    private int checkDeprovisioned() {
+        var deprovisionedProcesses = transferProcessStore.nextForState(DEPROVISIONED.code(), batchSize);
+
+        for (var process : deprovisionedProcesses) {
+            invokeForEach(l -> l.deprovisioned(process));
+            process.transitionEnded();
+            transferProcessStore.update(process);
+            invokeForEach(l -> l.ended(process));
+            monitor.debug("Process " + process.getId() + " is now " + TransferProcessStates.from(process.getState()));
+        }
+        return deprovisionedProcesses.size();
+    }
+
+    /**
+     * Transitions all processes that are in state DEPROVISIONING_REQ and deprovisions their associated
+     * resources. Then they are moved to DEPROVISIONING
+     *
+     * @return the number of transfer processes in DEPROVISIONING_REQ
+     */
+    private int checkDeprovisioningRequested() {
+        List<TransferProcess> processesDeprovisioning = transferProcessStore.nextForState(DEPROVISIONING_REQ.code(), batchSize);
+
+        for (var process : processesDeprovisioning) {
+            process.transitionDeprovisioning();
+            transferProcessStore.update(process);
+            invokeForEach(l -> l.deprovisioning(process));
+            monitor.debug("Process " + process.getId() + " is now " + TransferProcessStates.from(process.getState()));
+            provisionManager.deprovision(process);
+        }
+
+        return processesDeprovisioning.size();
+    }
+
+
+    /**
+     * Transition all processes, who have provisioned resources, into the IN_PROCRESS or STREAMING status, depending on
+     * whether they're finite or not.
+     * If a process does not have provisioned resources, it will remain in REQUESTED_ACK.
+     */
+    private int checkProvisioned() {
+        var requestAcked = transferProcessStore.nextForState(TransferProcessStates.REQUESTED_ACK.code(), batchSize);
+
+        for (var process : requestAcked) {
+            // process must either have a non-empty list of provisioned resources, or not have managed resources at all.
+            if (!process.getDataRequest().isManagedResources() || (process.getProvisionedResourceSet() != null && !process.getProvisionedResourceSet().empty())) {
+
+                if (process.getDataRequest().getTransferType().isFinite()) {
+                    process.transitionInProgress();
+                } else {
+                    process.transitionStreaming();
+                }
+                transferProcessStore.update(process);
+                invokeForEach(l -> l.inProgress(process));
+                monitor.debug("Process " + process.getId() + " is now " + TransferProcessStates.from(process.getState()));
+            } else {
+                monitor.debug("Process " + process.getId() + " does not yet have provisioned resources, will stay in " + TransferProcessStates.REQUESTED_ACK);
+            }
+        }
+
+        return requestAcked.size();
+
+    }
+
+    /**
+     * Checks all provisioned resources that are assigned to a transfer process for completion. If no StatusChecker exists
+     * for a particular ProvisionedResource, it is automatically assumed to be complete.
+     */
+    private int checkCompleted() {
+
+        //deal with all the consumer processes
+        var processesInProgress = transferProcessStore.nextForState(TransferProcessStates.IN_PROGRESS.code(), batchSize);
+
+        for (var process : processesInProgress.stream().filter(p -> p.getType() == CONSUMER).collect(Collectors.toList())) {
+            if (process.getDataRequest().isManagedResources()) {
+                var resources = process.getProvisionedResourceSet().getResources();
+                var checker = statusCheckerRegistry.resolve(process.getDataRequest().getDestinationType());
+                if (checker == null) {
+                    monitor.info(format("No checker found for process %s. The process will not advance to the COMPLETED state.", process.getId()));
+                } else if (checker.isComplete(process, resources)) {
+                    // checker passed, transition the process to the COMPLETED state
+                    transitionToCompleted(process);
+                }
+            } else {
+                var checker = statusCheckerRegistry.resolve(process.getDataRequest().getDestinationType());
+                if (checker != null) {
+                    if (checker.isComplete(process, emptyList())) {
+                        //checker passed, transition the process to the COMPLETED state automatically
+                        transitionToCompleted(process);
+                    }
+                } else {
+                    //no checker, transition the process to the COMPLETED state automatically
+                    transitionToCompleted(process);
+                }
+            }
+        }
+        return processesInProgress.size();
+    }
+
+    private void transitionToCompleted(TransferProcess process) {
+        process.transitionCompleted();
+        monitor.debug("Process " + process.getId() + " is now " + TransferProcessStates.COMPLETED);
+        transferProcessStore.update(process);
+        invokeForEach(listener -> listener.completed(process));
+    }
+
+
+    /**
+     * Performs consumer-side or provider side provisioning for a service.
+     * <br/>
+     * On a consumer, provisioning may entail setting up a data destination and supporting infrastructure. On a provider, provisioning is initiated when a request is received and
+     * map involve preprocessing data or other operations.
+     */
+    private int provisionInitialProcesses() {
+        var processes = transferProcessStore.nextForState(INITIAL.code(), batchSize);
+        for (TransferProcess process : processes) {
+            DataRequest dataRequest = process.getDataRequest();
+            ResourceManifest manifest;
+            if (process.getType() == CONSUMER) {
+                // if resources are managed by this connector, generate the manifest; otherwise create an empty one
+                manifest = dataRequest.isManagedResources() ? manifestGenerator.generateConsumerManifest(process) : ResourceManifest.Builder.newInstance().build();
+            } else {
+                manifest = manifestGenerator.generateProviderManifest(process);
+            }
+            process.transitionProvisioning(manifest);
+            transferProcessStore.update(process);
+            invokeForEach(l -> l.provisioning(process));
+            provisionManager.provision(process);
+        }
+        return processes.size();
+    }
+
+    /**
+     * On a consumer, sends provisioned requests to the provider connector. On the provider, sends provisioned requests to the data flow manager.
+     *
+     * @return the number of requests processed
+     */
+    private int sendOrProcessProvisionedRequests() {
+        var processes = transferProcessStore.nextForState(PROVISIONED.code(), batchSize);
+        for (TransferProcess process : processes) {
+            DataRequest dataRequest = process.getDataRequest();
+            if (CONSUMER == process.getType()) {
+                process.transitionRequested();
+                transferProcessStore.update(process);   // update before sending to accommodate synchronous transports; reliability will be managed by retry and idempotency
+                invokeForEach(l -> l.requested(process));
+                dispatcherRegistry.send(Void.class, dataRequest, process::getId);
+            } else {
+                var response = dataFlowManager.initiate(dataRequest);
+                if (ResponseStatus.ERROR_RETRY == response.getStatus()) {
+                    monitor.severe("Error processing transfer request. Setting to retry: " + process.getId());
+                    process.transitionProvisioned();
+                    transferProcessStore.update(process);
+                    invokeForEach(l -> l.provisioned(process));
+                } else if (ResponseStatus.FATAL_ERROR == response.getStatus()) {
+                    monitor.severe(format("Fatal error processing transfer request: %s. Error details: %s", process.getId(), response.getError()));
+                    process.transitionError(response.getError());
+                    transferProcessStore.update(process);
+                    invokeForEach(l -> l.error(process));
+                } else {
+                    if (process.getDataRequest().getTransferType().isFinite()) {
+                        process.transitionInProgress();
+                    } else {
+                        process.transitionStreaming();
+                    }
+                    transferProcessStore.update(process);
+                    invokeForEach(l -> l.inProgress(process));
+                }
+            }
+        }
+        return processes.size();
+    }
+
+
+    private void invokeForEach(Consumer<TransferProcessListener> action) {
+        getListeners().forEach(action);
+    }
+
+    public static class Builder {
+        private final TransferProcessManagerImpl manager;
+
+        private Builder() {
+            manager = new TransferProcessManagerImpl();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder batchSize(int size) {
+            manager.batchSize = size;
+            return this;
+        }
+
+        public Builder waitStrategy(TransferWaitStrategy waitStrategy) {
+            manager.waitStrategy = waitStrategy;
+            return this;
+        }
+
+        public Builder manifestGenerator(ResourceManifestGenerator manifestGenerator) {
+            manager.manifestGenerator = manifestGenerator;
+            return this;
+        }
+
+        public Builder provisionManager(ProvisionManager provisionManager) {
+            manager.provisionManager = provisionManager;
+            return this;
+        }
+
+        public Builder dataFlowManager(DataFlowManager dataFlowManager) {
+            manager.dataFlowManager = dataFlowManager;
+            return this;
+        }
+
+        public Builder dispatcherRegistry(RemoteMessageDispatcherRegistry registry) {
+            manager.dispatcherRegistry = registry;
+            return this;
+        }
+
+        public Builder monitor(Monitor monitor) {
+            manager.monitor = monitor;
+            return this;
+        }
+
+        public Builder statusCheckerRegistry(StatusCheckerRegistry statusCheckerRegistry) {
+            manager.statusCheckerRegistry = statusCheckerRegistry;
+            return this;
+        }
+
+        public TransferProcessManagerImpl build() {
+            Objects.requireNonNull(manager.manifestGenerator, "manifestGenerator");
+            Objects.requireNonNull(manager.provisionManager, "provisionManager");
+            Objects.requireNonNull(manager.dataFlowManager, "dataFlowManager");
+            Objects.requireNonNull(manager.dispatcherRegistry, "dispatcherRegistry");
+            Objects.requireNonNull(manager.monitor, "monitor");
+            Objects.requireNonNull(manager.statusCheckerRegistry, "StatusCheckerRegistry cannot be null!");
+            return manager;
+        }
+    }
+}

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobOrchestrator.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobOrchestrator.java
@@ -161,7 +161,7 @@ public class JobOrchestrator {
      */
     /* package */ void transferProcessError(TransferProcess process) {
         final var jobEntry = jobStore.findByProcessId(process.getId());
-        if (!jobEntry.isPresent()) {
+        if (jobEntry.isEmpty()) {
             monitor.severe("Job not found for transfer " + process.getId());
             return;
         }

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobOrchestrator.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobOrchestrator.java
@@ -154,6 +154,22 @@ public class JobOrchestrator {
         callCompleteHandlerIfFinished(job.getJobId());
     }
 
+    /**
+     * Callback invoked when a transfer fails.
+     *
+     * @param process
+     */
+    /* package */ void transferProcessError(TransferProcess process) {
+        final var jobEntry = jobStore.findByProcessId(process.getId());
+        if (!jobEntry.isPresent()) {
+            monitor.severe("Job not found for transfer " + process.getId());
+            return;
+        }
+        final var job = jobEntry.get();
+        monitor.info("Transfer failed in job " + job.getJobId());
+        jobStore.markJobInError(job.getJobId(), "Transfer failed");
+    }
+
     private void callCompleteHandlerIfFinished(final String jobId) {
         jobStore.find(jobId).ifPresent(job -> {
             if (job.getState() != JobState.TRANSFERS_FINISHED) {

--- a/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobTransferCallback.java
+++ b/coreservices/partsrelationshipservice/connector/edc-recursive-job/src/main/java/net/catenax/prs/connector/job/JobTransferCallback.java
@@ -35,4 +35,14 @@ class JobTransferCallback implements TransferProcessListener {
     public void completed(final TransferProcess process) {
         jobOrchestrator.transferProcessCompleted(process);
     }
+
+    /**
+     * Callback invoked by the EDC framework when a transfer fails.
+     *
+     * @param process
+     */
+    @Override
+    public void error(TransferProcess process) {
+        jobOrchestrator.transferProcessError(process);
+    }
 }

--- a/coreservices/partsrelationshipservice/connector/edc-transfer-process-watchdog/pom.xml
+++ b/coreservices/partsrelationshipservice/connector/edc-transfer-process-watchdog/pom.xml
@@ -33,6 +33,13 @@
             <version>${spotbugs.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- edc-patched-core needs to appear before any other edc dependency to allow overriding of EDC classes -->
+        <dependency>
+            <groupId>net.catenax.prs</groupId>
+            <artifactId>edc-patched-core</artifactId>
+            <version>${revision}</version>
+            <scope>compile</scope>
+        </dependency>
         <dependency>
             <groupId>org.eclipse.dataspaceconnector</groupId>
             <artifactId>core</artifactId>

--- a/coreservices/partsrelationshipservice/connector/edc-transfer-process-watchdog/src/main/java/org/eclipse/dataspaceconnector/transfer/core/TransferProcessWatchdogExtension.java
+++ b/coreservices/partsrelationshipservice/connector/edc-transfer-process-watchdog/src/main/java/org/eclipse/dataspaceconnector/transfer/core/TransferProcessWatchdogExtension.java
@@ -13,6 +13,7 @@ package org.eclipse.dataspaceconnector.transfer.core;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.transfer.core.transfer.TransferProcessWatchdog;
 
@@ -52,7 +53,8 @@ public class TransferProcessWatchdogExtension implements ServiceExtension {
     @Override
     public void start() {
         var transferProcessStore = context.getService(TransferProcessStore.class);
-        watchdog.start(transferProcessStore);
+        var transferProcessManager = context.getService(TransferProcessManager.class);
+        watchdog.start(transferProcessStore, transferProcessManager);
         monitor.info("Started Transfer Process Watchdog extension");
     }
 

--- a/coreservices/partsrelationshipservice/connector/edc-transfer-process-watchdog/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessWatchdog.java
+++ b/coreservices/partsrelationshipservice/connector/edc-transfer-process-watchdog/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessWatchdog.java
@@ -12,6 +12,7 @@ package org.eclipse.dataspaceconnector.transfer.core.transfer;
 
 import lombok.Builder;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 
 import java.util.concurrent.Executors;
@@ -34,12 +35,13 @@ public class TransferProcessWatchdog {
         this.stateTimeoutInMs = stateTimeoutInMs;
     }
 
-    public void start(TransferProcessStore processStore) {
+    public void start(TransferProcessStore processStore, TransferProcessManager transferProcessManager) {
         var action = CancelLongRunningProcesses.builder()
                 .monitor(monitor)
                 .stateTimeoutInMs(stateTimeoutInMs)
                 .batchSize(batchSize)
                 .transferProcessStore(processStore)
+                .transferProcessManager(transferProcessManager)
                 .build();
         executor = Executors.newSingleThreadScheduledExecutor();
         executor.scheduleWithFixedDelay(action, 0, delayInMs, TimeUnit.MILLISECONDS);

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/controller/ConsumerApiController.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/main/java/net/catenax/prs/connector/consumer/controller/ConsumerApiController.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import net.catenax.prs.connector.consumer.middleware.RequestMiddleware;
 import net.catenax.prs.connector.consumer.service.ConsumerService;
 import net.catenax.prs.connector.consumer.service.StatusResponse;
+import net.catenax.prs.connector.job.JobState;
 import net.catenax.prs.connector.parameters.GetStatusParameters;
 import net.catenax.prs.connector.requests.PartsTreeRequest;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -110,6 +111,9 @@ public class ConsumerApiController {
                     final StatusResponse statusResponse = status.get();
                     if (statusResponse.getSasToken() != null) {
                         return Response.ok(statusResponse.getSasToken()).build();
+                    }
+                    if (statusResponse.getStatus() == JobState.ERROR) {
+                        return Response.serverError().build();
                     }
                     return Response.accepted(statusResponse.getStatus().toString()).build();
                 });

--- a/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/test/java/net/catenax/prs/connector/consumer/controller/ConsumerApiControllerTests.java
+++ b/coreservices/partsrelationshipservice/connector/prs-connector-consumer/src/test/java/net/catenax/prs/connector/consumer/controller/ConsumerApiControllerTests.java
@@ -122,23 +122,22 @@ public class ConsumerApiControllerTests {
     }
 
     @Test
-    public void getStatus_WhenSuccess_ReturnsStatus() {
+    public void getStatus_WhenError_ReturnsStatus() {
         // Arrange
         when(service.getStatus(parameters.getRequestId())).thenReturn(Optional.of(
-                StatusResponse.builder().status(jobStatus).build()));
+                StatusResponse.builder().status(JobState.ERROR).build()));
         // Act
         var response = controller.getStatus(parameters);
         // Assert
-        assertThat(response.getEntity()).isEqualTo(jobStatus.name());
-        assertThat(response.getStatus()).isEqualTo(Response.Status.ACCEPTED.getStatusCode());
+        assertThat(response.getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
     }
 
     @ParameterizedTest
     @EnumSource(
             value = JobState.class,
-            names = {"COMPLETED"},
+            names = {"COMPLETED", "ERROR"},
             mode = EnumSource.Mode.EXCLUDE)
-    public void getStatus_WhenNotCompleted_ReturnsStatus(JobState jobStatus) {
+    public void getStatus_WhenNotCompletedNorError_ReturnsStatus(JobState jobStatus) {
         // Arrange
         when(service.getStatus(parameters.getRequestId())).thenReturn(Optional.of(
                 StatusResponse.builder().status(jobStatus).build()));

--- a/coreservices/partsrelationshipservice/connector/run-integration-test.sh
+++ b/coreservices/partsrelationshipservice/connector/run-integration-test.sh
@@ -8,5 +8,12 @@ if [ ! -f dev/local/cert.pfx ]; then
 fi
 
 export DOCKER_BUILDKIT=1
+# Successful parts tree retrieval IT
 docker-compose --profile connector build --build-arg PRS_EDC_PKG_USERNAME=$PRS_EDC_PKG_USERNAME --build-arg PRS_EDC_PKG_PASSWORD=$PRS_EDC_PKG_PASSWORD
+IT_SCRIPT=connector-integration-test.sh \
 docker-compose --profile connector --profile prs up --exit-code-from=connector-integration-test --abort-on-container-exit
+
+# Failing parts tree retrieval IT (prs not available)
+docker-compose --profile connector build --build-arg PRS_EDC_PKG_USERNAME=$PRS_EDC_PKG_USERNAME --build-arg PRS_EDC_PKG_PASSWORD=$PRS_EDC_PKG_PASSWORD
+IT_SCRIPT=connector-api-failure-integration-test.sh \
+docker-compose --profile connector up --exit-code-from=connector-integration-test --abort-on-container-exit

--- a/coreservices/partsrelationshipservice/dev/connector-api-failure-integration-test.sh
+++ b/coreservices/partsrelationshipservice/dev/connector-api-failure-integration-test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+curl -O https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
+chmod +x wait-for-it.sh
+curl -O https://raw.githubusercontent.com/kadwanev/retry/master/retry
+chmod +x retry
+./wait-for-it.sh -t 60 provider:8181
+./wait-for-it.sh -t 60 consumer:8181
+
+# Send request to consumer connector
+requestId=$(curl -f -X POST http://consumer:8181/api/v0.1/retrievePartsTree -H "Content-type:application/json" -d '{"byObjectIdRequest": {
+    "oneIDManufacturer": "BMW MUC", "objectIDManufacturer": "YS3DD78N4X7055320", "view": "AS_BUILT", "aspect": "MATERIAL", "depth": 2}}')
+
+# Poll status endpoint until job completed
+stateUrl="http://consumer:8181/api/v0.1/datarequest/$requestId/state"
+./retry -s 1 -t 120 "test \$(curl -f -o /dev/null -s -w '%{http_code}' $stateUrl) == 500"
+
+echo "Job failed as expected"

--- a/coreservices/partsrelationshipservice/docker-compose.yml
+++ b/coreservices/partsrelationshipservice/docker-compose.yml
@@ -111,6 +111,7 @@ services:
       edc.vault.tenantid: ${edc_vault_tenantid}
       edc.vault.certificate: /devlocal/cert.pfx
       edc.vault.name: ${edc_vault_name}
+      edc.watchdog.timeout: 10000 # 10s timeout
       edc.storage.account.name: ${edc_storage_account_name}
       prs.dataspace.partitions: /files/dataspace-partitions.json
       prs.dataspace.partition.deployments: /files/dataspace-deployments.json
@@ -126,7 +127,7 @@ services:
       - connector
     container_name: connector-test
     image: adoptopenjdk:11-jre-hotspot
-    command: dev-files/connector-integration-test.sh
+    command: dev-files/${IT_SCRIPT}
     volumes:
       - ./dev:/dev-files
 


### PR DESCRIPTION
Adapt watchdog to use `cancelProcess` method from TransferProcessManager. The cancelProcess method calls the corresponding listeners, which allows for the job orchestration framework to cancel jobs whenever a transfer fails.

The `cancelProcess` method has been added to the edc-patched-core module. See separate contribution here: https://github.com/Agera-CatenaX/EclipseDataSpaceConnector/pull/7. Once this contribution is merged it can be removed from edc-patched-core.

An integration test for a case with failing calls to PRS has been added.