### PR TITLE
Introduce open id connect flow for swagger ui

### DIFF
--- a/infrastructure/manifests/semantics.yaml
+++ b/infrastructure/manifests/semantics.yaml
@@ -90,6 +90,7 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/x-forwarded-prefix: "/semantics"
 spec:
   ingressClassName: service
   tls:

--- a/semantics/services/src/main/java/net/catenax/semantics/OAuthSecurityConfig.java
+++ b/semantics/services/src/main/java/net/catenax/semantics/OAuthSecurityConfig.java
@@ -14,7 +14,8 @@ public class OAuthSecurityConfig extends WebSecurityConfigurerAdapter {
         http
           .authorizeRequests(auth -> auth
             .antMatchers(HttpMethod.OPTIONS).permitAll()
-            .antMatchers("/**/twins/**").authenticated()
+            .antMatchers("/**/registry/**").authenticated()
+            .antMatchers("/**/lookup/**").authenticated()
             .antMatchers("/**/models/**").authenticated())
           .oauth2ResourceServer()
           .jwt();

--- a/semantics/services/src/main/java/net/catenax/semantics/SemanticsServicesApplication.java
+++ b/semantics/services/src/main/java/net/catenax/semantics/SemanticsServicesApplication.java
@@ -13,12 +13,14 @@ import org.springdoc.core.SpringDocConfigProperties;
 import org.springdoc.core.SpringDocConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jdbc.repository.config.EnableJdbcAuditing;
 import org.springframework.security.web.firewall.HttpFirewall;
 import org.springframework.security.web.firewall.StrictHttpFirewall;
-import org.springframework.data.jdbc.repository.config.EnableJdbcAuditing;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /**
@@ -30,12 +32,20 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @ComponentScan(basePackages = {"net.catenax.semantics", "org.openapitools.configuration"})
 public class SemanticsServicesApplication {
 
+	private static final String OPEN_ID_CONNECT_DISCOVERY_PATH = "/.well-known/openid-configuration";
+
 	@Bean
-	public WebMvcConfigurer configurer() {
+	public WebMvcConfigurer configurer(OAuth2ResourceServerProperties securityProperties) {
 		return new WebMvcConfigurer(){
 			@Override
 			public void addCorsMappings(CorsRegistry registry) {
-			  registry.addMapping("/**").allowedOrigins("*").allowedMethods("*");
+			    registry.addMapping("/**").allowedOrigins("*").allowedMethods("*");
+			}
+			@Override
+			public void addViewControllers(ViewControllerRegistry registry){
+				// this redirect ensures that the SwaggerUI can get the open id discovery data
+				String fullDiscoveryPath = securityProperties.getJwt().getIssuerUri() + OPEN_ID_CONNECT_DISCOVERY_PATH;
+				registry.addRedirectViewController(OPEN_ID_CONNECT_DISCOVERY_PATH, fullDiscoveryPath);
 			}
 		};
 	}
@@ -48,6 +58,7 @@ public class SemanticsServicesApplication {
 	public SpringDocConfigProperties springDocConfigProperties() {
 		return new SpringDocConfigProperties();
 	}
+
 
 	@Bean
     public HttpFirewall allowUrlEncodedSlashHttpFirewall() {

--- a/semantics/services/src/main/resources/application.yml
+++ b/semantics/services/src/main/resources/application.yml
@@ -95,6 +95,8 @@ spring:
 title: '@project.name@'
 
 springdoc:
+  cache:
+    disabled: true
   api-docs:
     enabled: false
   swagger-ui:

--- a/semantics/services/src/main/resources/application.yml
+++ b/semantics/services/src/main/resources/application.yml
@@ -103,6 +103,11 @@ springdoc:
        url: /aas-registry-openapi.yaml
      - name: SemanticHub API
        url: /semantic-hub-openapi.yaml
+    oauth:
+      use-pkce-with-authorization-code-grant: true
+      # the scopes and client id will be prefilled in the swagger ui
+      scopes: openid profile
+      client-id: catenax-portal
 
 project_desc: '@project.description@'
 contact_email: '@email@'

--- a/semantics/services/src/main/resources/application.yml
+++ b/semantics/services/src/main/resources/application.yml
@@ -29,6 +29,7 @@ server:
     key-store-type: PKCS12
     key-alias: 1
     enabled: false
+  forward-headers-strategy: framework
 
 hub:
   triple-store:

--- a/semantics/services/src/main/resources/static/aas-registry-openapi.yaml
+++ b/semantics/services/src/main/resources/static/aas-registry-openapi.yaml
@@ -9,9 +9,9 @@ info:
   contact:
     name: Michael Hoffmeister, Torben Miny, Andreas Orzelski, Manuel Sauer, Constantin Ziesche
   version: Final-Draft
+
 servers:
-- url: /semantics/
-- url: /
+- url: ./
 
 security:
   - CatenaXOpenId:
@@ -736,7 +736,7 @@ components:
   securitySchemes:
     CatenaXOpenId:
       type: openIdConnect
-      openIdConnectUrl: /.well-known/openid-configuration
+      openIdConnectUrl: ../.well-known/openid-configuration
 
   examples:
     minimal-asset-administration-shell-descriptor:

--- a/semantics/services/src/main/resources/static/aas-registry-openapi.yaml
+++ b/semantics/services/src/main/resources/static/aas-registry-openapi.yaml
@@ -10,7 +10,13 @@ info:
     name: Michael Hoffmeister, Torben Miny, Andreas Orzelski, Manuel Sauer, Constantin Ziesche
   version: Final-Draft
 servers:
+- url: /semantics/
 - url: /
+
+security:
+  - CatenaXOpenId:
+      - profile
+
 paths:
   /registry/shell-descriptors:
     get:
@@ -726,6 +732,12 @@ components:
           additionalProperties:
             type: object
           description: An object with key/value pairs containing additional information about the error.
+
+  securitySchemes:
+    CatenaXOpenId:
+      type: openIdConnect
+      openIdConnectUrl: /.well-known/openid-configuration
+
   examples:
     minimal-asset-administration-shell-descriptor:
       value:


### PR DESCRIPTION
This PR introduces OpenIdConnect to the AAS SwaggerUI.
Users can now directly authenticate through SwaggerUI and try out the API.

In addition the reverse proxy issue (/semantics) is fixed. 

Due to redirect url restrictions of the hosted Catena-X Keycloak instance, I was only able to test this with a local Keycloak instance.