### PR TITLE
DAPS update to latest version

### DIFF
--- a/daps/helm-chart/Chart.yaml
+++ b/daps/helm-chart/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.0.0
+appVersion: 1.4.2

--- a/daps/helm-chart/templates/configmap.yml
+++ b/daps/helm-chart/templates/configmap.yml
@@ -68,7 +68,9 @@ data:
     - client_id: admin
       name: omejdn admin ui
       allowed_scopes:
-      - omejdn:api
+      - omejdn:read
+      - omejdn:write
+      - omejdn:admin
       redirect_uri: https://oauth.pstmn.io/v1/callback
       attributes: []
   {{- end }}

--- a/daps/helm-chart/templates/deployment.yaml
+++ b/daps/helm-chart/templates/deployment.yaml
@@ -37,10 +37,11 @@ spec:
         args:
         - |
           ls /tmp/
-          # if [ ! -f /tmp/users.yml ]; then
+          cp /opt/config/omejdn.yml /tmp/omejdn.yml
+          if [ ! -f /tmp/users.yml ]; then
             echo "File users.yml not found in pvc!. Creating empty file"
             touch /tmp/users.yml
-          # fi
+          fi
           if [ -d /tmp/key.pem ]; then
             echo "Fix key is directory"
             rm -rf /tmp/key.pem
@@ -73,6 +74,9 @@ spec:
           name: config
           subPath: keys
           readOnly: false
+        - mountPath: /opt/config/omejdn.yml
+          name: omejdn-config
+          subPath: omejdn.yml
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -80,10 +84,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-          - name: OMEJDN_JWT_AUD_OVERRIDE
-            value: "idsc:IDS_CONNECTORS_ALL"
-          - name: OMEJDN_IGNORE_ENV
-            value: "true"
+          # - name: OMEJDN_JWT_AUD_OVERRIDE
+          #   value: "idsc:IDS_CONNECTORS_ALL"
+          # - name: OMEJDN_IGNORE_ENV
+          #   value: "false"
           {{- if .Values.omejdn.createDefaultAdmin }}
           - name: OMEJDN_ADMIN
             value: {{ .Values.omejdn.defaultAdminUser }}
@@ -111,7 +115,8 @@ spec:
               path: /.well-known/jwks.json
               port: http              
               scheme: HTTP
-            failureThreshold: 3
+            failureThreshold: 5
+            timeoutSeconds: 3
             periodSeconds: 3
           readinessProbe:
             httpGet:
@@ -119,12 +124,13 @@ spec:
               port: http              
               scheme: HTTP
             failureThreshold: 3
-            periodSeconds: 1
+            timeoutSeconds: 3
+            periodSeconds: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
           - mountPath: /opt/config/omejdn.yml
-            name: omejdn-config
+            name: config
             subPath: omejdn.yml
           - mountPath: {{ .Values.omejdn.serverKeyFolderPath }}/key.pem
             name: config

--- a/daps/helm-chart/templates/ingress.yaml
+++ b/daps/helm-chart/templates/ingress.yaml
@@ -50,41 +50,4 @@ spec:
             servicePort: {{ default $svcPort .port }}
           {{- end }}
         
----
-{{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}-jwks
-  labels:
-    {{- include "omejdn-server.labels" . | nindent 4 }}
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /.well-known/jwks.json
-    {{- if .Values.ingress.tls.certMgr.enabled }}
-    cert-manager.io/issuer: {{ .Values.ingress.tls.certMgr.issuer }}
-    {{- end }}
-spec:
-  ingressClassName: service
-  rules:
-    - host: {{ .Values.ingress.host }}
-      http:
-        paths:
-          - path: /.well-known/jwks.json
-            pathType: Prefix
-            backend:
-              {{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-              
 {{- end }}

--- a/daps/helm-chart/values.yaml
+++ b/daps/helm-chart/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 image:
   # -- DAPS docker image
-  repository: nginx
+  repository: ghcr.io/fraunhofer-aisec/omejdn-server
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Image tag. Overrides the image tag whose default is the chart appVersion.
@@ -100,19 +100,19 @@ env:
 # -- Pod resources requests and limits configuration
 resources:
   limits:
-    cpu: 200m
-    memory: 100Mi
+    cpu: 150m
+    memory: 128Mi
   requests:
-    cpu: 200m
-    memory: 100Mi
+    cpu: 150m
+    memory: 128Mi
 
 # -- DAPS autoscaling configuration
 autoscaling:
   enabled: true
   minReplicas: 1
   maxReplicas: 5
-  # targetCPUUtilizationPercentage: 60
-  targetMemoryUtilizationPercentage: 60
+  targetCPUUtilizationPercentage: 70
+  # targetMemoryUtilizationPercentage: 60
 
 # -- Node selection configuration
 nodeSelector: {}


### PR DESCRIPTION
This PR updates helm chart to run latest (1.4.2) version of DAPS server.
Changes:
- Default admin client scopes changed;
- ConfigMap now mounted through empty volume, because app changing `omejdn.yml` during startup;
- Pods Autoscaler changes: now it looks at CPU usage instead of memory. Limits reworked.