### PR TITLE
Bugfix/catx a1 sldt@a1 sldt 415 semantichub duplicates

### DIFF
--- a/semantics/services/src/main/java/net/catenax/semantics/hub/persistence/triplestore/SparqlQueries.java
+++ b/semantics/services/src/main/java/net/catenax/semantics/hub/persistence/triplestore/SparqlQueries.java
@@ -124,8 +124,8 @@ public class SparqlQueries {
          "SELECT DISTINCT ?aspect (?status as ?statusResult)\n"
                + FILTER_QUERY_WHERE_CLAUSE
                + "ORDER BY lcase(str(?aspect))\n"
-               + "OFFSET  0\n"
-               + "LIMIT   10";
+               + "OFFSET  $offsetParam\n"
+               + "LIMIT   $limitParam";
 
    private static final String COUNT_ASPECT_MODELS_QUERY =
          "SELECT (count(DISTINCT ?aspect) as ?aspectModelCount)\n"
@@ -200,8 +200,11 @@ public class SparqlQueries {
    }
 
    private static Integer getOffset( int page, int pageSize ) {
-      if ( page <= 1 ) {
-         return 0;
+      if ( page == 0 ) {
+         return page;
+      }
+      if ( page == 1){
+         return page * pageSize;
       }
       return (page - 1) * pageSize;
    }

--- a/semantics/services/src/main/java/net/catenax/semantics/hub/persistence/triplestore/TripleStorePersistence.java
+++ b/semantics/services/src/main/java/net/catenax/semantics/hub/persistence/triplestore/TripleStorePersistence.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -223,11 +224,10 @@ public class TripleStorePersistence implements PersistenceLayer {
 
    private static List<SemanticModel> aspectModelFrom(
          final List<QuerySolution> querySolutions ) {
-      final Map<String, SemanticModel> aspectModels = new HashMap<>();
-      querySolutions.stream()
-                    .map( TripleStorePersistence::aspectModelFrom )
-                    .forEach( aspectModel -> aspectModels.putIfAbsent( aspectModel.getName(), aspectModel ) );
-      return new ArrayList<>( aspectModels.values() );
+      return  querySolutions
+              .stream()
+              .map( TripleStorePersistence::aspectModelFrom )
+              .collect(Collectors.toList());
    }
 
    private static SemanticModel aspectModelFrom( final QuerySolution querySolution ) {

--- a/semantics/services/src/test/java/net/catenax/semantics/hub/ModelsApiFilterTest.java
+++ b/semantics/services/src/test/java/net/catenax/semantics/hub/ModelsApiFilterTest.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) 2022 Bosch Software Innovations GmbH. All rights reserved.
+ * Copyright (c) 2022 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package net.catenax.semantics.hub;

--- a/semantics/services/src/test/java/net/catenax/semantics/hub/ModelsApiPaginationTest.java
+++ b/semantics/services/src/test/java/net/catenax/semantics/hub/ModelsApiPaginationTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2022 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.catenax.semantics.hub;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Tests the models filter api with different filter combinations.
+ * The Fuseki Server is cleared with @DirtiesContext and ensures test runs on a fresh Fuseki Server.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestInstance( TestInstance.Lifecycle.PER_CLASS )
+@DirtiesContext( classMode = DirtiesContext.ClassMode.AFTER_CLASS )
+public class ModelsApiPaginationTest {
+   @Autowired
+   private MockMvc mvc;
+
+   @Test
+   public void testGetModelsWithPaginationExpectSuccess() throws Exception {
+      List<String> prefixes = List.of(
+              "urn:bamm:net.catenax.pagination.a:1.0.0#",
+              "urn:bamm:net.catenax.pagination.b:1.0.0#",
+              "urn:bamm:net.catenax.pagination.c:1.0.0#",
+              "urn:bamm:net.catenax.pagination.d:1.0.0#"
+      );
+
+      prefixes.forEach(urnPrefix -> {
+         try {
+            mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix, "DRAFT")  ))
+                    .andDo( MockMvcResultHandlers.print() )
+                    .andExpect( status().isOk() );
+         } catch (Exception e) {
+           throw new RuntimeException(e);
+         }
+      });
+
+
+      mvc.perform(
+                      MockMvcRequestBuilders.get( "/api/v1/models" )
+                              .accept( MediaType.APPLICATION_JSON )
+              )
+        .andDo( MockMvcResultHandlers.print() )
+        .andExpect( jsonPath( "$.items" ).isArray() )
+        .andExpect( jsonPath( "$.items[*]", hasSize(4) ) )
+        .andExpect( jsonPath( "$.totalItems", equalTo(4) ) )
+        .andExpect( jsonPath( "$.totalPages", equalTo(1) ) )
+        .andExpect( jsonPath( "$.itemCount", equalTo( 4) ) )
+        .andExpect( status().isOk() );
+
+      mvc.perform(
+                      MockMvcRequestBuilders.get( "/api/v1/models?pageSize=2&page=0" )
+                              .accept( MediaType.APPLICATION_JSON )
+              )
+              .andDo( MockMvcResultHandlers.print() )
+              .andExpect( jsonPath( "$.items" ).isArray() )
+              .andExpect( jsonPath( "$.items[*]", hasSize(2) ) )
+              .andExpect( jsonPath( "$.items[*].urn", hasItems( toMovementUrn(prefixes.get(0)), toMovementUrn(prefixes.get(1)) ) ) )
+              .andExpect( jsonPath( "$.items[*].version", hasItem( "1.0.0" ) ) )
+              .andExpect( jsonPath( "$.items[*].name", hasItem( "Movement" ) ) )
+              .andExpect( jsonPath( "$.items[*].type", hasItem( "BAMM" ) ) )
+              .andExpect( jsonPath( "$.items[*].status", hasItem( "DRAFT" ) ) )
+              .andExpect( jsonPath( "$.totalItems", equalTo(4) ) )
+              .andExpect( jsonPath( "$.totalPages", equalTo(2) ) )
+              .andExpect( jsonPath( "$.itemCount", equalTo( 2 ) ) )
+              .andExpect( status().isOk() );
+
+      mvc.perform(
+                      MockMvcRequestBuilders.get( "/api/v1/models?pageSize=2&page=1" )
+                              .accept( MediaType.APPLICATION_JSON )
+              )
+              .andDo( MockMvcResultHandlers.print() )
+              .andExpect( jsonPath( "$.items" ).isArray() )
+              .andExpect( jsonPath( "$.items[*]", hasSize(2) ) )
+              .andExpect( jsonPath( "$.items[*].urn", hasItems( toMovementUrn(prefixes.get(2)), toMovementUrn(prefixes.get(3) ) ) ))
+              .andExpect( jsonPath( "$.items[*].version", hasItem( "1.0.0" ) ) )
+              .andExpect( jsonPath( "$.items[*].name", hasItem( "Movement" ) ) )
+              .andExpect( jsonPath( "$.items[*].type", hasItem( "BAMM" ) ) )
+              .andExpect( jsonPath( "$.items[*].status", hasItem( "DRAFT" ) ) )
+              .andExpect( jsonPath( "$.totalItems", equalTo(4) ) )
+              .andExpect( jsonPath( "$.totalPages", equalTo(2) ) )
+              .andExpect( jsonPath( "$.itemCount", equalTo( 2 ) ) )
+              .andExpect( status().isOk() );
+
+      mvc.perform(
+                      MockMvcRequestBuilders.get( "/api/v1/models?pageSize=1&page=3" )
+                              .accept( MediaType.APPLICATION_JSON )
+              )
+              .andDo( MockMvcResultHandlers.print() )
+              .andExpect( jsonPath( "$.items" ).isArray() )
+              .andExpect( jsonPath( "$.items[*]", hasSize(1) ) )
+              .andExpect( jsonPath( "$.items[*].urn", hasItems( toMovementUrn(prefixes.get(2) ) ) ))
+              .andExpect( jsonPath( "$.items[*].version", hasItem( "1.0.0" ) ) )
+              .andExpect( jsonPath( "$.items[*].name", hasItem( "Movement" ) ) )
+              .andExpect( jsonPath( "$.items[*].type", hasItem( "BAMM" ) ) )
+              .andExpect( jsonPath( "$.items[*].status", hasItem( "DRAFT" ) ) )
+              .andExpect( jsonPath( "$.totalItems", equalTo(4) ) )
+              .andExpect( jsonPath( "$.totalPages", equalTo(4) ) )
+              .andExpect( jsonPath( "$.itemCount", equalTo( 1 ) ) )
+              .andExpect( status().isOk() );
+   }
+
+   private MockHttpServletRequestBuilder post(String payload ) {
+      return MockMvcRequestBuilders.post( "/api/v1/models" )
+              .accept( MediaType.APPLICATION_JSON )
+              .contentType( MediaType.APPLICATION_JSON )
+              .content( payload );
+   }
+
+   private static String toMovementUrn(String urn){
+      return urn + "Movement";
+   }
+
+}

--- a/semantics/services/src/test/java/net/catenax/semantics/hub/ModelsApiTest.java
+++ b/semantics/services/src/test/java/net/catenax/semantics/hub/ModelsApiTest.java
@@ -1,11 +1,25 @@
+/*
+ * Copyright (c) 2022 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.catenax.semantics.hub;
 
-import static org.hamcrest.Matchers.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -15,6 +29,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @AutoConfigureMockMvc


### PR DESCRIPTION
This PR fixes two bugs:

Aspects with the same name but different namespaces were considered as duplicates. This was wrong and not needed anyway because of a DISTINCT in the Sparql Query.
The pagination did not considered the query parameters. I fixed it, there is now a test case for pagination.