### PR TITLE
Add local profile with disabled security

### DIFF
--- a/semantics/services/README.md
+++ b/semantics/services/README.md
@@ -14,6 +14,19 @@ The source code under this folder contains reference implementations of relevant
 - Semantic Hub
 
 ### Build Packages:
+The project requires on private package from https://maven.pkg.github.com/eclipse-dataspaceconnector/DataSpaceConnector.
+Add the following configuration to your `.m2/settings.xml`:
+
+```
+    <server>
+        <id>edc-github</id>
+        <username>oauth2</username>
+        <password>$ADD_GITHUB_ACCESS_TOKEN_HERE</password>
+    </server>
+```
+
+You need to add your own GitHub Access Token. Navigate to https://github.com/settings/tokens and create a new token
+with the permission `read:packages`. 
 
 Run `mvn install` to run unit tests, build and install the package (and submodules)
 

--- a/semantics/services/pom.xml
+++ b/semantics/services/pom.xml
@@ -68,6 +68,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.json</groupId>

--- a/semantics/services/src/main/java/net/catenax/semantics/LocalOauthSecurityConfig.java
+++ b/semantics/services/src/main/java/net/catenax/semantics/LocalOauthSecurityConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2022 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.catenax.semantics;
 
 import org.springframework.context.annotation.Configuration;

--- a/semantics/services/src/main/java/net/catenax/semantics/LocalOauthSecurityConfig.java
+++ b/semantics/services/src/main/java/net/catenax/semantics/LocalOauthSecurityConfig.java
@@ -1,0 +1,18 @@
+package net.catenax.semantics;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Profile("local")
+@Configuration
+public class LocalOauthSecurityConfig extends WebSecurityConfigurerAdapter {
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .authorizeRequests(auth -> auth
+                        .anyRequest().permitAll())
+                .csrf().disable();
+    }
+}

--- a/semantics/services/src/main/java/net/catenax/semantics/OAuthSecurityConfig.java
+++ b/semantics/services/src/main/java/net/catenax/semantics/OAuthSecurityConfig.java
@@ -20,12 +20,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
+@Profile("!local")
 @Configuration
-@EnableWebSecurity
-@Profile("!test")
 public class OAuthSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {

--- a/semantics/services/src/main/java/net/catenax/semantics/SemanticsServicesApplication.java
+++ b/semantics/services/src/main/java/net/catenax/semantics/SemanticsServicesApplication.java
@@ -26,9 +26,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /**
  * Main Adapter Application
- * TODO make sure openapi description is correct, referrer-header should give us a hint.
  */
-@SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
+@SpringBootApplication
 @EnableJdbcAuditing
 @ComponentScan(basePackages = {"net.catenax.semantics", "org.openapitools.configuration"})
 public class SemanticsServicesApplication {

--- a/semantics/services/src/main/java/net/catenax/semantics/registry/model/support/DatabaseExceptionTranslation.java
+++ b/semantics/services/src/main/java/net/catenax/semantics/registry/model/support/DatabaseExceptionTranslation.java
@@ -26,7 +26,6 @@ public class DatabaseExceptionTranslation {
 
     private static final Pattern SUBMODEL = Pattern.compile("(SUBMODEL_SHELL_AK_01)|(ON.*SUBMODEL)");
     private static final Pattern SHELL = Pattern.compile("(SHELL_AK_01)|(ON.*SHELL)");
-    private static final Pattern IDENTIFIER = Pattern.compile("(SHELL_IDENTIFIER_AK_01)|(ON.*SHELL_IDENTIFIER)");
 
     public static String translate(DuplicateKeyException exception){
         String message = exception.getMessage();
@@ -38,10 +37,6 @@ public class DatabaseExceptionTranslation {
 
         if(SUBMODEL.matcher(upperCaseMessage).find()) {
             return "A SubmodelDescriptor with the given identification does already exists for this AssetAdministrationShell.";
-        }
-
-        if(IDENTIFIER.matcher(upperCaseMessage).find()) {
-            return "A specificAssetId for the given key does already exist.";
         }
 
         if(SHELL.matcher(upperCaseMessage).find()) {

--- a/semantics/services/src/main/resources/application-local.yml
+++ b/semantics/services/src/main/resources/application-local.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 T-Systems International GmbH (Catena-X Consortium)
+# Copyright (c) 2022 Robert Bosch Manufacturing Solutions GmbH
 #
 # See the AUTHORS file(s) distributed with this work for additional
 # information regarding authorship.

--- a/semantics/services/src/main/resources/application-local.yml
+++ b/semantics/services/src/main/resources/application-local.yml
@@ -1,0 +1,18 @@
+# Copyright (c) 2021-2022 T-Systems International GmbH (Catena-X Consortium)
+#
+# See the AUTHORS file(s) distributed with this work for additional
+# information regarding authorship.
+#
+# See the LICENSE file(s) distributed with this work for
+# additional information regarding license terms.
+#
+
+###########################################################
+# Configuration of the Semantic Layer
+##########################################################
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri:

--- a/semantics/services/src/main/resources/db/changelog/db.changelog-v1.yaml
+++ b/semantics/services/src/main/resources/db/changelog/db.changelog-v1.yaml
@@ -304,3 +304,11 @@ databaseChangeLog:
                   name: NAMESPACE
               - column:
                   name: IDENTIFIER
+  - changeSet:
+      id: 02032022-01
+      author: fmisir
+      changes:
+        - dropUniqueConstraint:
+            tableName: SHELL_IDENTIFIER
+            constraintName: SHELL_IDENTIFIER_AK_01
+            uniqueColumns: KEY, FK_SHELL_ID

--- a/semantics/services/src/test/java/net/catenax/semantics/TestOAuthSecurityConfig.java
+++ b/semantics/services/src/test/java/net/catenax/semantics/TestOAuthSecurityConfig.java
@@ -17,20 +17,25 @@
 package net.catenax.semantics;
 
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.core.annotation.Order;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 
-@Order(1)
+import java.time.Instant;
+import java.util.Map;
+
 @TestConfiguration
-@EnableWebSecurity
-public class TestOAuthSecurityConfig extends WebSecurityConfigurerAdapter {
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http
-          .authorizeRequests(auth -> auth
-            .anyRequest().permitAll())
-          .csrf().disable();
+public class TestOAuthSecurityConfig {
+
+    @Bean
+    public JwtDecoder jwtDecoder(){
+        return token -> new Jwt(
+                "token",
+                Instant.now(),
+                Instant.MAX,
+                Map.of("alg", "none"),
+                Map.of(JwtClaimNames.SUB, "testUser")
+        );
     }
 }

--- a/semantics/services/src/test/java/net/catenax/semantics/hub/ModelsApiFilterTest.java
+++ b/semantics/services/src/test/java/net/catenax/semantics/hub/ModelsApiFilterTest.java
@@ -17,6 +17,7 @@
 package net.catenax.semantics.hub;
 
 import static org.hamcrest.Matchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -56,6 +57,7 @@ public class ModelsApiFilterTest {
                MockMvcRequestBuilders.get(
                                            "/api/v1/models?namespaceFilter=urn:bamm:com.catena" )
                                      .accept( MediaType.APPLICATION_JSON )
+                                     .with(jwt())
          )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( jsonPath( "$.items" ).isArray() )
@@ -68,6 +70,7 @@ public class ModelsApiFilterTest {
                MockMvcRequestBuilders.get(
                                            "/api/v1/models?namespaceFilter=urn:bamm:com.catenax.traceability" )
                                      .accept( MediaType.APPLICATION_JSON )
+                                     .with(jwt())
          )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( jsonPath( "$.items" ).isArray() )
@@ -83,6 +86,7 @@ public class ModelsApiFilterTest {
                MockMvcRequestBuilders.get(
                                            "/api/v1/models?nameType=bamm:SingleEntity&nameFilter=SpatialPositionCharacteristic" )
                                      .accept( MediaType.APPLICATION_JSON )
+                                     .with(jwt())
          )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( jsonPath( "$.items" ).isArray() )
@@ -98,6 +102,7 @@ public class ModelsApiFilterTest {
                MockMvcRequestBuilders.get(
                                            "/api/v1/models?nameType=bamm:Property&nameFilter=Static%20Data" )
                                      .accept( MediaType.APPLICATION_JSON )
+                                     .with(jwt())
          )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( jsonPath( "$.items" ).isArray() )
@@ -110,6 +115,7 @@ public class ModelsApiFilterTest {
                MockMvcRequestBuilders.get(
                                            "/api/v1/models?nameType=bamm:Property&nameFilter=Individual%20Data" )
                                      .accept( MediaType.APPLICATION_JSON )
+                                     .with(jwt())
          )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( jsonPath( "$.items" ).isArray() )
@@ -123,6 +129,7 @@ public class ModelsApiFilterTest {
                MockMvcRequestBuilders.get(
                                            "/api/v1/models?namespaceFilter=urn:bamm:com.catenax.traceability&nameType=bamm:Property&nameFilter=Individual%20Data" )
                                      .accept( MediaType.APPLICATION_JSON )
+                                     .with(jwt())
          )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( jsonPath( "$.items" ).isArray() )
@@ -135,6 +142,7 @@ public class ModelsApiFilterTest {
                MockMvcRequestBuilders.get(
                                            "/api/v1/models?namespaceFilter=urn:bamm:com.catenaX.modelwithreferencetotraceability&nameType=bamm:Property&nameFilter=Individual%20Data" )
                                      .accept( MediaType.APPLICATION_JSON )
+                                     .with(jwt())
          )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( jsonPath( "$.items" ).isArray() )
@@ -150,6 +158,7 @@ public class ModelsApiFilterTest {
                MockMvcRequestBuilders.get(
                                            "/api/v1/models?nameType=_DESCRIPTION_&nameFilter=This%20model%20references" )
                                      .accept( MediaType.APPLICATION_JSON )
+                                     .with(jwt())
          )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( jsonPath( "$.items.length()" ).value( 1 ) )
@@ -169,6 +178,7 @@ public class ModelsApiFilterTest {
       mvc.perform(
                MockMvcRequestBuilders.get( "/api/v1/models?status=DRAFT" )
                                      .accept( MediaType.APPLICATION_JSON )
+                                     .with(jwt())
          )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( jsonPath( "$.items" ).isArray() )
@@ -185,6 +195,7 @@ public class ModelsApiFilterTest {
       mvc.perform(
                MockMvcRequestBuilders.get( "/api/v1/models?status=RELEASED" )
                                      .accept( MediaType.APPLICATION_JSON )
+                                     .with(jwt())
          )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( jsonPath( "$.items" ).isArray() )
@@ -207,6 +218,7 @@ public class ModelsApiFilterTest {
                      .accept( MediaType.APPLICATION_JSON )
                      .contentType( MediaType.APPLICATION_JSON )
                      .content( TestUtils.createNewModelRequestJson( modelWithReferenceToTraceability, status ) )
+                     .with(jwt())
          )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( status().isOk() );

--- a/semantics/services/src/test/java/net/catenax/semantics/hub/ModelsApiPaginationTest.java
+++ b/semantics/services/src/test/java/net/catenax/semantics/hub/ModelsApiPaginationTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -46,6 +47,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestInstance( TestInstance.Lifecycle.PER_CLASS )
 @DirtiesContext( classMode = DirtiesContext.ClassMode.AFTER_CLASS )
 public class ModelsApiPaginationTest {
+
    @Autowired
    private MockMvc mvc;
 
@@ -72,6 +74,7 @@ public class ModelsApiPaginationTest {
       mvc.perform(
                       MockMvcRequestBuilders.get( "/api/v1/models" )
                               .accept( MediaType.APPLICATION_JSON )
+                              .with(jwt())
               )
         .andDo( MockMvcResultHandlers.print() )
         .andExpect( jsonPath( "$.items" ).isArray() )
@@ -84,6 +87,7 @@ public class ModelsApiPaginationTest {
       mvc.perform(
                       MockMvcRequestBuilders.get( "/api/v1/models?pageSize=2&page=0" )
                               .accept( MediaType.APPLICATION_JSON )
+                              .with(jwt())
               )
               .andDo( MockMvcResultHandlers.print() )
               .andExpect( jsonPath( "$.items" ).isArray() )
@@ -101,6 +105,7 @@ public class ModelsApiPaginationTest {
       mvc.perform(
                       MockMvcRequestBuilders.get( "/api/v1/models?pageSize=2&page=1" )
                               .accept( MediaType.APPLICATION_JSON )
+                              .with(jwt())
               )
               .andDo( MockMvcResultHandlers.print() )
               .andExpect( jsonPath( "$.items" ).isArray() )
@@ -118,6 +123,7 @@ public class ModelsApiPaginationTest {
       mvc.perform(
                       MockMvcRequestBuilders.get( "/api/v1/models?pageSize=1&page=3" )
                               .accept( MediaType.APPLICATION_JSON )
+                              .with(jwt())
               )
               .andDo( MockMvcResultHandlers.print() )
               .andExpect( jsonPath( "$.items" ).isArray() )
@@ -135,6 +141,7 @@ public class ModelsApiPaginationTest {
       mvc.perform(
                       MockMvcRequestBuilders.get( "/api/v1/models?pageSize=3" )
                               .accept( MediaType.APPLICATION_JSON )
+                              .with(jwt())
               )
               .andDo( MockMvcResultHandlers.print() )
               .andExpect( jsonPath( "$.items" ).isArray() )
@@ -156,7 +163,8 @@ public class ModelsApiPaginationTest {
       return MockMvcRequestBuilders.post( "/api/v1/models" )
               .accept( MediaType.APPLICATION_JSON )
               .contentType( MediaType.APPLICATION_JSON )
-              .content( payload );
+              .content( payload )
+              .with(jwt());
    }
 
    private static String toMovementUrn(String urn){

--- a/semantics/services/src/test/java/net/catenax/semantics/registry/AssetAdministrationShellApiTest.java
+++ b/semantics/services/src/test/java/net/catenax/semantics/registry/AssetAdministrationShellApiTest.java
@@ -260,6 +260,29 @@ public class AssetAdministrationShellApiTest {
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNoContent());
         }
+
+        /**
+         * It must be possible to create multiple specificAssetIds for the same key.
+         */
+        @Test
+        public void testCreateShellWithSameSpecificAssetIdKeyButDifferentValuesExpectSuccess() throws Exception{
+            ObjectNode shellPayload = createBaseIdPayload("example", "example");
+            shellPayload.set("specificAssetIds", emptyArrayNode()
+                    .add(specificAssetId("WMI", "1234123"))
+                    .add(specificAssetId("WMI", "fug01"))
+            );
+            mvc.perform(
+                            MockMvcRequestBuilders
+                                    .post(SHELL_BASE_PATH)
+                                    .accept(MediaType.APPLICATION_JSON)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(toJson(shellPayload))
+                                    .with(jwt())
+                    )
+                    .andDo(MockMvcResultHandlers.print())
+                    .andExpect(status().isCreated())
+                    .andExpect(content().json(toJson(shellPayload)));
+        }
     }
 
     @Nested

--- a/semantics/services/src/test/java/net/catenax/semantics/registry/AssetAdministrationShellApiTest.java
+++ b/semantics/services/src/test/java/net/catenax/semantics/registry/AssetAdministrationShellApiTest.java
@@ -16,11 +16,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
@@ -40,6 +39,32 @@ public class AssetAdministrationShellApiTest {
 
     @Autowired
     private ObjectMapper mapper;
+
+    @Nested
+    @DisplayName("Security tests")
+    class SecurityTests {
+        @Test
+        public void testWithoutAuthenticationTokenProvidedExpectForbidden() throws Exception {
+            mvc.perform(
+                            MockMvcRequestBuilders
+                                    .get(SINGLE_SHELL_BASE_PATH, UUID.randomUUID())
+                                    .accept(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(MockMvcResultHandlers.print())
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        public void testWithAuthenticationTokenProvidedExpectSuccess() throws Exception {
+            mvc.perform(
+                            MockMvcRequestBuilders
+                                    .get(SINGLE_SHELL_BASE_PATH, UUID.randomUUID())
+                                    .accept(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(MockMvcResultHandlers.print())
+                    .andExpect(status().isUnauthorized());
+        }
+    }
 
     @Nested
     @DisplayName("Shell CRUD API")
@@ -66,6 +91,7 @@ public class AssetAdministrationShellApiTest {
                                     .accept(MediaType.APPLICATION_JSON)
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(toJson(shellPayload))
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isBadRequest())
@@ -81,6 +107,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .get(SINGLE_SHELL_BASE_PATH, shellId)
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
@@ -93,6 +120,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .get(SINGLE_SHELL_BASE_PATH, "NotExistingShellId")
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNotFound());
@@ -107,6 +135,7 @@ public class AssetAdministrationShellApiTest {
                                     .get(SHELL_BASE_PATH)
                                     .queryParam("pageSize", "100")
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
@@ -133,6 +162,7 @@ public class AssetAdministrationShellApiTest {
                                     .accept(MediaType.APPLICATION_JSON)
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(toJson(updateDescription))
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNoContent());
@@ -141,6 +171,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .get(SINGLE_SHELL_BASE_PATH, shellId)
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
@@ -156,6 +187,7 @@ public class AssetAdministrationShellApiTest {
                                     .accept(MediaType.APPLICATION_JSON)
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(toJson(createShell(false)))
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNotFound())
@@ -179,6 +211,7 @@ public class AssetAdministrationShellApiTest {
                                     .accept(MediaType.APPLICATION_JSON)
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(toJson(updatedShell))
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNoContent());
@@ -191,6 +224,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .get(SINGLE_SHELL_BASE_PATH, shellId)
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
@@ -206,6 +240,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .delete(SINGLE_SHELL_BASE_PATH, shellId)
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNoContent());
@@ -220,6 +255,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .delete(SINGLE_SHELL_BASE_PATH, shellId)
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNoContent());
@@ -241,6 +277,7 @@ public class AssetAdministrationShellApiTest {
                                     .get(LOOKUP_SHELL_BASE_PATH)
                                     .queryParam("assetIds", toJson(multipleAssetIdParam))
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
@@ -250,6 +287,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .delete(SINGLE_SHELL_BASE_PATH, shellId)
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNoContent());
@@ -276,6 +314,7 @@ public class AssetAdministrationShellApiTest {
                                     .accept(MediaType.APPLICATION_JSON)
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(toJson(specificAssetIds))
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isCreated())
@@ -303,6 +342,7 @@ public class AssetAdministrationShellApiTest {
                                     .accept(MediaType.APPLICATION_JSON)
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(toJson(specificAssetIds))
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isCreated())
@@ -314,6 +354,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .get(SINGLE_SHELL_BASE_PATH, shellId)
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
@@ -330,6 +371,7 @@ public class AssetAdministrationShellApiTest {
                                     .accept(MediaType.APPLICATION_JSON)
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(toJson(specificAssetIds))
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNotFound())
@@ -346,6 +388,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .get(SINGLE_LOOKUP_SHELL_BASE_PATH, shellId)
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
@@ -358,6 +401,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .get(SINGLE_LOOKUP_SHELL_BASE_PATH, "notexistingshell", "notexistingsubmodel")
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNotFound())
@@ -383,6 +427,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .get(SINGLE_SHELL_BASE_PATH, shellId)
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
@@ -403,6 +448,7 @@ public class AssetAdministrationShellApiTest {
                                     .accept(MediaType.APPLICATION_JSON)
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(toJson(existingSubmodel))
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isBadRequest())
@@ -429,6 +475,7 @@ public class AssetAdministrationShellApiTest {
                                     .accept(MediaType.APPLICATION_JSON)
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(toJson(updatedSubmodel))
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNoContent());
@@ -437,6 +484,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .get(SINGLE_SUB_MODEL_BASE_PATH, shellId, submodelId)
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
@@ -450,6 +498,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .get(SINGLE_SUB_MODEL_BASE_PATH, "notexistingshell", "notexistingsubmodel")
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNotFound())
@@ -464,6 +513,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .get(SINGLE_SUB_MODEL_BASE_PATH, shellId, "notexistingsubmodel")
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNotFound())
@@ -491,6 +541,7 @@ public class AssetAdministrationShellApiTest {
                                     .accept(MediaType.APPLICATION_JSON)
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(toJson(updatedSubmodel))
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNoContent());
@@ -503,6 +554,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .get(SINGLE_SUB_MODEL_BASE_PATH, shellId, submodelId)
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
@@ -524,6 +576,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .delete(SINGLE_SUB_MODEL_BASE_PATH, shellId, submodelId)
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNoContent());
@@ -532,6 +585,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .get(SINGLE_SUB_MODEL_BASE_PATH, shellId, submodelId)
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNotFound());
@@ -544,6 +598,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .delete(SINGLE_SUB_MODEL_BASE_PATH, "notexistingshell", "notexistingsubmodel")
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNotFound())
@@ -558,6 +613,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .delete(SINGLE_SUB_MODEL_BASE_PATH, shellId, "notexistingsubmodel")
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isNotFound())
@@ -576,6 +632,7 @@ public class AssetAdministrationShellApiTest {
                                     .get(LOOKUP_SHELL_BASE_PATH)
                                     .queryParam("assetIds", "{ invalid }")
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isBadRequest())
@@ -590,6 +647,7 @@ public class AssetAdministrationShellApiTest {
                                     .get(LOOKUP_SHELL_BASE_PATH)
                                     .queryParam("assetIds", swaggerUIEscapedAssetIds)
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
@@ -628,6 +686,7 @@ public class AssetAdministrationShellApiTest {
                                     .get(LOOKUP_SHELL_BASE_PATH)
                                     .queryParam("assetIds", toJson(allSpecificAssetIdsForFirstShell))
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
@@ -643,6 +702,7 @@ public class AssetAdministrationShellApiTest {
                                     .get(LOOKUP_SHELL_BASE_PATH)
                                     .queryParam("assetIds", toJson(oneAssetIdForFirstShell))
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
@@ -658,6 +718,7 @@ public class AssetAdministrationShellApiTest {
                                     .get(LOOKUP_SHELL_BASE_PATH)
                                     .queryParam("assetIds", toJson(commonAssetIdBothShells))
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
@@ -683,6 +744,7 @@ public class AssetAdministrationShellApiTest {
                                     .get(LOOKUP_SHELL_BASE_PATH)
                                     .queryParam("assetIds", toJson(globalAssetIdForSampleQuery))
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
@@ -699,6 +761,7 @@ public class AssetAdministrationShellApiTest {
                             MockMvcRequestBuilders
                                     .get(LOOKUP_SHELL_BASE_PATH)
                                     .accept(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
@@ -725,6 +788,7 @@ public class AssetAdministrationShellApiTest {
                                     .accept(MediaType.APPLICATION_JSON)
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(toJson(batchShellBody))
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isCreated())
@@ -751,6 +815,7 @@ public class AssetAdministrationShellApiTest {
                                     .accept(MediaType.APPLICATION_JSON)
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(toJson(batchShellBody))
+                                    .with(jwt())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isCreated())
@@ -771,6 +836,7 @@ public class AssetAdministrationShellApiTest {
                                 .accept(MediaType.APPLICATION_JSON)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(payload)
+                                .with(jwt())
                 )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isCreated())
@@ -799,6 +865,7 @@ public class AssetAdministrationShellApiTest {
                                 .accept(MediaType.APPLICATION_JSON)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(payload)
+                                .with(jwt())
                 )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isCreated())


### PR DESCRIPTION
This PR introduces a local profile with disabled security.

By starting the AAS Registry with the environment variable "SPRING_PROFILES_ACTIVE=local", security will be disabled.
Allowing developers to implement against the AAS Registry.

I also removed the test profile and adjusted the test to use security.

In addition the unique constraints on specificAssetIds#key is removed. 
