### PR TITLE
Feature/catx a1 sldt1@a1 sldt 367 implement fetch api

### DIFF
--- a/semantics/registry/src/main/java/net/catenax/semantics/registry/controller/AssetAdministrationShellApiDelegate.java
+++ b/semantics/registry/src/main/java/net/catenax/semantics/registry/controller/AssetAdministrationShellApiDelegate.java
@@ -128,7 +128,7 @@ public class AssetAdministrationShellApiDelegate implements RegistryApiDelegate,
         if( assetIds == null || assetIds.isEmpty()){
             return new ResponseEntity<>(Collections.emptyList(), HttpStatus.OK);
         }
-        List<String> externalIds = shellService.findExternalShellIdsByIdentifiers(shellMapper.fromApiDto(assetIds));
+        List<String> externalIds = shellService.findExternalShellIdsByIdentifiersByExactMatch(shellMapper.fromApiDto(assetIds));
         return new ResponseEntity<>(externalIds, HttpStatus.OK);
     }
 
@@ -150,4 +150,13 @@ public class AssetAdministrationShellApiDelegate implements RegistryApiDelegate,
         List<BatchResultDto> batchResults = shellService.saveBatch(shells);
         return new ResponseEntity<>(shellMapper.toListApiDto(batchResults), HttpStatus.CREATED);
     }
+
+    @Override
+    public ResponseEntity<List<String>> getAllAssetAdministrationShellIdsByQuery(ShellLookup shellLookup) {
+        List<IdentifierKeyValuePair> assetIds = shellLookup.getQuery().getAssetIds();
+        List<String> externalIds = shellService.findExternalShellIdsByIdentifiersByAnyMatch(shellMapper.fromApiDto(assetIds));
+        return new ResponseEntity<>(externalIds, HttpStatus.OK);
+    }
+
 }
+

--- a/semantics/registry/src/main/java/net/catenax/semantics/registry/controller/AssetAdministrationShellApiDelegate.java
+++ b/semantics/registry/src/main/java/net/catenax/semantics/registry/controller/AssetAdministrationShellApiDelegate.java
@@ -166,11 +166,10 @@ public class AssetAdministrationShellApiDelegate implements RegistryApiDelegate,
     }
 
     @Override
-    public ResponseEntity<List<String>> getAllAssetAdministrationShellIdsByQuery(ShellLookup shellLookup) {
+    public ResponseEntity<List<String>> postQueryAllAssetAdministrationShellIds(ShellLookup shellLookup) {
         List<IdentifierKeyValuePair> assetIds = shellLookup.getQuery().getAssetIds();
         List<String> externalIds = shellService.findExternalShellIdsByIdentifiersByAnyMatch(shellMapper.fromApiDto(assetIds));
         return new ResponseEntity<>(externalIds, HttpStatus.OK);
     }
-
 }
 

--- a/semantics/registry/src/main/java/net/catenax/semantics/registry/controller/AssetAdministrationShellApiDelegate.java
+++ b/semantics/registry/src/main/java/net/catenax/semantics/registry/controller/AssetAdministrationShellApiDelegate.java
@@ -17,7 +17,13 @@ package net.catenax.semantics.registry.controller;
 
 import net.catenax.semantics.aas.registry.api.LookupApiDelegate;
 import net.catenax.semantics.aas.registry.api.RegistryApiDelegate;
-import net.catenax.semantics.aas.registry.model.*;
+import net.catenax.semantics.aas.registry.model.AssetAdministrationShellDescriptor;
+import net.catenax.semantics.aas.registry.model.AssetAdministrationShellDescriptorCollection;
+import net.catenax.semantics.aas.registry.model.AssetAdministrationShellDescriptorCollectionBase;
+import net.catenax.semantics.aas.registry.model.BatchResult;
+import net.catenax.semantics.aas.registry.model.IdentifierKeyValuePair;
+import net.catenax.semantics.aas.registry.model.ShellLookup;
+import net.catenax.semantics.aas.registry.model.SubmodelDescriptor;
 import net.catenax.semantics.registry.dto.BatchResultDto;
 import net.catenax.semantics.registry.mapper.ShellMapper;
 import net.catenax.semantics.registry.mapper.SubmodelMapper;
@@ -31,6 +37,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.NativeWebRequest;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -57,6 +64,13 @@ public class AssetAdministrationShellApiDelegate implements RegistryApiDelegate,
     @Override
     public ResponseEntity<AssetAdministrationShellDescriptorCollection> getAllAssetAdministrationShellDescriptors(Integer page, Integer pageSize) {
         return new ResponseEntity<>(shellMapper.toApiDto(shellService.findAllShells(page, pageSize)), HttpStatus.OK);
+    }
+
+    @Override
+    public ResponseEntity<AssetAdministrationShellDescriptorCollectionBase> postFetchAssetAdministrationShellDescriptor(List<String> shellIdentifications) {
+        List<Shell> shellsByExternalShellIds = shellService.findShellsByExternalShellIds(new HashSet<>(shellIdentifications));
+        return new ResponseEntity<>(new AssetAdministrationShellDescriptorCollectionBase()
+                        .items(shellMapper.toApiDto(shellsByExternalShellIds)), HttpStatus.OK);
     }
 
     @Override

--- a/semantics/registry/src/main/java/net/catenax/semantics/registry/repository/ShellRepository.java
+++ b/semantics/registry/src/main/java/net/catenax/semantics/registry/repository/ShellRepository.java
@@ -44,7 +44,7 @@ public interface ShellRepository extends PagingAndSortingRepository<Shell, UUID>
      *
      * @param keyValueCombinations the keys values to search for as tuples
      * @param keyValueCombinationsSize the size of the key value combinations
-     * @return external shell ids for the given keys and values
+     * @return external shell ids for the given key value combinations
      */
     @Query(
             "select s.id_external from shell s where s.id in (" +
@@ -60,13 +60,13 @@ public interface ShellRepository extends PagingAndSortingRepository<Shell, UUID>
 
     /**
      * Returns external shell ids for the given keyValueCombinations.
-     * Only external shell ids that match all keyValueCombinations are returned.
+     * External shell ids that match any keyValueCombinations are returned.
      *
      * To be able to properly index the key and value conditions, the query does not use any functions.
      * Computed indexes cannot be created for mutable functions like CONCAT in Postgres.
      *
      * @param keyValueCombinations the keys values to search for as tuples
-     * @return external shell ids for the given keys and values
+     * @return external shell ids for the given key value combinations
      */
     @Query(
             "select distinct s.id_external from shell s where s.id in (" +

--- a/semantics/registry/src/main/java/net/catenax/semantics/registry/repository/ShellRepository.java
+++ b/semantics/registry/src/main/java/net/catenax/semantics/registry/repository/ShellRepository.java
@@ -33,6 +33,8 @@ public interface ShellRepository extends PagingAndSortingRepository<Shell, UUID>
     @Query("select s.id, s.created_date from shell s where s.id_external = :idExternal")
     Optional<ShellMinimal> findMinimalRepresentationByIdExternal(String idExternal);
 
+    List<Shell> findShellsByIdExternalIsIn(Set<String> idExternals);
+
     /**
      * Returns external shell ids for the given keyValueCombinations.
      * Only external shell ids that match all keyValueCombinations are returned.

--- a/semantics/registry/src/main/java/net/catenax/semantics/registry/service/ShellService.java
+++ b/semantics/registry/src/main/java/net/catenax/semantics/registry/service/ShellService.java
@@ -81,9 +81,14 @@ public class ShellService {
                 .build();
     }
 
-    public List<String> findExternalShellIdsByIdentifiers(Set<ShellIdentifier> shellIdentifiers){
+    public List<String> findExternalShellIdsByIdentifiersByExactMatch(Set<ShellIdentifier> shellIdentifiers){
         List<String[]> keyValueCombinations = shellIdentifiers.stream().map(shellIdentifier -> new String[]{shellIdentifier.getKey(), shellIdentifier.getValue()}).collect(Collectors.toList());
-        return shellRepository.findExternalShellIdsByIdentifiers(keyValueCombinations, keyValueCombinations.size());
+        return shellRepository.findExternalShellIdsByIdentifiersByExactMatch(keyValueCombinations, keyValueCombinations.size());
+    }
+
+    public List<String> findExternalShellIdsByIdentifiersByAnyMatch(Set<ShellIdentifier> shellIdentifiers){
+        List<String[]> keyValueCombinations = shellIdentifiers.stream().map(shellIdentifier -> new String[]{shellIdentifier.getKey(), shellIdentifier.getValue()}).collect(Collectors.toList());
+        return shellRepository.findExternalShellIdsByIdentifiersByAnyMatch(keyValueCombinations);
     }
 
     @Transactional

--- a/semantics/registry/src/main/java/net/catenax/semantics/registry/service/ShellService.java
+++ b/semantics/registry/src/main/java/net/catenax/semantics/registry/service/ShellService.java
@@ -81,14 +81,21 @@ public class ShellService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
     public List<String> findExternalShellIdsByIdentifiersByExactMatch(Set<ShellIdentifier> shellIdentifiers){
         List<String[]> keyValueCombinations = shellIdentifiers.stream().map(shellIdentifier -> new String[]{shellIdentifier.getKey(), shellIdentifier.getValue()}).collect(Collectors.toList());
         return shellRepository.findExternalShellIdsByIdentifiersByExactMatch(keyValueCombinations, keyValueCombinations.size());
     }
 
+    @Transactional(readOnly = true)
     public List<String> findExternalShellIdsByIdentifiersByAnyMatch(Set<ShellIdentifier> shellIdentifiers){
         List<String[]> keyValueCombinations = shellIdentifiers.stream().map(shellIdentifier -> new String[]{shellIdentifier.getKey(), shellIdentifier.getValue()}).collect(Collectors.toList());
         return shellRepository.findExternalShellIdsByIdentifiersByAnyMatch(keyValueCombinations);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Shell> findShellsByExternalShellIds(Set<String> externalShellIds){
+        return shellRepository.findShellsByIdExternalIsIn(externalShellIds);
     }
 
     @Transactional

--- a/semantics/registry/src/main/resources/static/aas-registry-openapi.yaml
+++ b/semantics/registry/src/main/resources/static/aas-registry-openapi.yaml
@@ -529,7 +529,7 @@ paths:
       tags:
         - Registry and Discovery Interface
       summary: Returns a list of Asset Administration Shell ids based on Asset identifier key-value-pairs.
-      operationId: GetAllAssetAdministrationShellIdsByQuery
+      operationId: PostQueryAllAssetAdministrationShellIds
       requestBody:
         description: Asset Administration Shell Descriptor object
         content:

--- a/semantics/registry/src/main/resources/static/aas-registry-openapi.yaml
+++ b/semantics/registry/src/main/resources/static/aas-registry-openapi.yaml
@@ -881,15 +881,15 @@ components:
           ],
           "globalAssetId": {
             "value": [
-                "192fc530-c69b-3707-25f6-5dbc2e9baaa8"
+                "urn:twin:net.catenax#3c7556f7-6956-4360-8036-d03e5a79c3c8"
             ]
           },
           "idShort": "future concept x",
           "identification": "882fc530-b69b-4707-95f6-5dbc5e9baaa8",
           "specificAssetIds": [
             {
-              "key": "engineserialid",
-              "value": "12309481209312"
+              "key": "PartInstanceID",
+              "value": "24975539203421"
             }
           ],
           "submodelDescriptors": [
@@ -897,23 +897,23 @@ components:
               "description": [
                 {
                   "language": "en",
-                  "text": "Provides base vehicle information"
+                  "text": "Provides traceability information"
                 }
               ],
-              "idShort": "vehicle base details",
+              "idShort": "traceability-info",
               "identification": "4a738a24-b7d8-4989-9cd6-387772f40565",
               "semanticId": {
                 "value": [
-                    "urn:bamm:com.catenax.vehicle:0.1.1"
+                    "urn:bamm:com.catenax:0.0.1#Traceability"
                 ]
               },
               "endpoints": [
                 {
-                  "interface": "HTTP",
+                  "interface": "SUBMODEL-1.0RC02",
                   "protocolInformation": {
-                    "endpointAddress": "https://catena-x.net/vehicle/basedetails/",
-                    "endpointProtocol": "HTTPS",
-                    "endpointProtocolVersion": "1.0"
+                    "endpointAddress": "edc://provider.connector:9191/offer-windchill/shells/882fc530-b69b-4707-95f6-5dbc5e9baaa8/aas/4a738a24-b7d8-4989-9cd6-387772f40565/submodel",
+                    "endpointProtocol": "IDS/ECLIPSE DATASPACE CONNECTOR",
+                    "endpointProtocolVersion": "0.0.1"
                   }
                 }
               ]
@@ -934,11 +934,11 @@ components:
               },
               "endpoints": [
                 {
-                  "interface": "HTTP",
+                  "interface": "SUBMODEL-1.0RC02",
                   "protocolInformation": {
-                    "endpointAddress": "https://catena-x.net/vehicle/partdetails/",
-                    "endpointProtocol": "HTTPS",
-                    "endpointProtocolVersion": "1.0"
+                    "endpointAddress": "edc://provider.connector:9191/offer-details/shells/882fc530-b69b-4707-95f6-5dbc5e9baaa8/aas/dae4d249-6d66-4818-b576-bf52f3b9ae90/submodel",
+                    "endpointProtocol": "IDS/ECLIPSE DATASPACE CONNECTOR",
+                    "endpointProtocolVersion": "0.0.1"
                   }
                 }
               ]
@@ -958,15 +958,15 @@ components:
               ],
               "globalAssetId": {
                 "value": [
-                    "192fc530-c69b-3707-25f6-5dbc2e9baaa8"
+                    "urn:twin:net.catenax#3c7556f7-6956-4360-8036-d03e5a79c3c8"
                 ]
               },
               "idShort": "future concept x",
               "identification": "882fc530-b69b-4707-95f6-5dbc5e9baaa8",
               "specificAssetIds": [
                 {
-                  "key": "engineserialid",
-                  "value": "12309481209312"
+                  "key": "PartInstanceID",
+                  "value": "24975539203421"
                 }
               ],
               "submodelDescriptors": [
@@ -974,23 +974,23 @@ components:
                   "description": [
                     {
                       "language": "en",
-                      "text": "Provides base vehicle information"
+                      "text": "Provides traceability information"
                     }
                   ],
-                  "idShort": "vehicle base details",
+                  "idShort": "traceability-info",
                   "identification": "4a738a24-b7d8-4989-9cd6-387772f40565",
                   "semanticId": {
                     "value": [
-                        "urn:bamm:com.catenax.vehicle:0.1.1"
+                        "urn:bamm:com.catenax:0.0.1#Traceability"
                     ]
                   },
                   "endpoints": [
                     {
-                      "interface": "HTTP",
+                      "interface": "SUBMODEL-1.0RC02",
                       "protocolInformation": {
-                        "endpointAddress": "https://catena-x.net/vehicle/basedetails/",
-                        "endpointProtocol": "HTTPS",
-                        "endpointProtocolVersion": "1.0"
+                        "endpointAddress": "edc://provider.connector:9191/offer-windchill/shells/882fc530-b69b-4707-95f6-5dbc5e9baaa8/aas/4a738a24-b7d8-4989-9cd6-387772f40565/submodel",
+                        "endpointProtocol": "IDS/ECLIPSE DATASPACE CONNECTOR",
+                        "endpointProtocolVersion": "0.0.1"
                       }
                     }
                   ]
@@ -1020,15 +1020,15 @@ components:
               ],
               "globalAssetId": {
                 "value": [
-                    "192fc530-c69b-3707-25f6-5dbc2e9baaa8"
+                    "urn:twin:net.catenax#3c7556f7-6956-4360-8036-d03e5a79c3c8"
                 ]
               },
               "idShort": "future concept x",
               "identification": "882fc530-b69b-4707-95f6-5dbc5e9baaa8",
               "specificAssetIds": [
                 {
-                  "key": "engineserialid",
-                  "value": "12309481209312"
+                  "key": "PartInstanceID",
+                  "value": "24975539203421"
                 }
               ],
               "submodelDescriptors": [
@@ -1036,23 +1036,23 @@ components:
                   "description": [
                     {
                       "language": "en",
-                      "text": "Provides base vehicle information"
+                      "text": "Provides traceability information"
                     }
                   ],
-                  "idShort": "vehicle base details",
+                  "idShort": "traceability-info",
                   "identification": "4a738a24-b7d8-4989-9cd6-387772f40565",
                   "semanticId": {
                     "value": [
-                        "urn:bamm:com.catenax.vehicle:0.1.1"
+                        "urn:bamm:com.catenax:0.0.1#Traceability"
                     ]
                   },
                   "endpoints": [
                     {
-                      "interface": "HTTP",
+                      "interface": "SUBMODEL-1.0RC02",
                       "protocolInformation": {
-                        "endpointAddress": "https://catena-x.net/vehicle/basedetails/",
-                        "endpointProtocol": "HTTPS",
-                        "endpointProtocolVersion": "1.0"
+                        "endpointAddress": "edc://provider.connector:9191/offer-windchill/shells/882fc530-b69b-4707-95f6-5dbc5e9baaa8/aas/4a738a24-b7d8-4989-9cd6-387772f40565/submodel",
+                        "endpointProtocol": "IDS/ECLIPSE DATASPACE CONNECTOR",
+                        "endpointProtocolVersion": "0.0.1"
                       }
                     }
                   ]
@@ -1089,77 +1089,65 @@ components:
             ],
             "globalAssetId": {
               "value": [
-                  "exampleGlobalAssetId"
+                  "urn:twin:net.catenax#3c7556f7-6956-4360-8036-d03e5a79c3c8"
               ]
             },
             "specificAssetIds": [
               {
-                "key": "PartId",
-                "value": "f10ujf2lkcb"
-              },
-              {
-                "key": "enginenumber1",
-                "value": "enginenumber1"
+                "key": "VAN",
+                "value": "WEBFC102u30912"
               }
             ],
             "submodelDescriptors": [
               {
-                "identification": "submodel_external1_a088b555-7a6c-4092-aed2-1c0e6e752e87",
-                "idShort": "exampleSubModelShortId",
                 "description": [
                   {
                     "language": "en",
-                    "text": "this is an example submodel description"
-                  },
-                  {
-                    "language": "de",
-                    "text": "das ist ein Beispiel submodel"
+                    "text": "Provides traceability information"
                   }
                 ],
-                "endpoints": [
-                  {
-                    "interface": "interfaceName",
-                    "protocolInformation": {
-                      "endpointAddress": "https://catena-xsubmodel-vechile.net/path",
-                      "endpointProtocol": "HTTPS",
-                      "endpointProtocolVersion": "1.0"
-                    }
-                  }
-                ],
+                "idShort": "traceability-info",
+                "identification": "4a738a24-b7d8-4989-9cd6-387772f40565",
                 "semanticId": {
                   "value": [
-                      "urn:net.catenax.vehicle:1.0.0#Parts"
+                      "urn:bamm:com.catenax:0.0.1#Traceability"
                   ]
-                }
+                },
+                "endpoints": [
+                  {
+                    "interface": "SUBMODEL-1.0RC02",
+                    "protocolInformation": {
+                      "endpointAddress": "edc://provider.connector:9191/offer-windchill/shells/882fc530-b69b-4707-95f6-5dbc5e9baaa8/aas/4a738a24-b7d8-4989-9cd6-387772f40565/submodel",
+                      "endpointProtocol": "IDS/ECLIPSE DATASPACE CONNECTOR",
+                      "endpointProtocolVersion": "0.0.1"
+                    }
+                  }
+                ]
               },
               {
-                "identification": "submodel_external2_2b41b06a-ffe3-47d2-b599-979ec63e978f",
-                "idShort": "exampleSubModelShortId",
                 "description": [
                   {
                     "language": "en",
-                    "text": "this is an example submodel description"
-                  },
-                  {
-                    "language": "de",
-                    "text": "das ist ein Beispiel submodel"
+                    "text": "Provides traceability information"
                   }
                 ],
-                "endpoints": [
-                  {
-                    "interface": "interfaceName",
-                    "protocolInformation": {
-                      "endpointAddress": "https://catena-xsubmodel-vechile.net/path",
-                      "endpointProtocol": "HTTPS",
-                      "endpointProtocolVersion": "1.0"
-                    }
-                  }
-                ],
+                "idShort": "traceability-info",
+                "identification": "4a738a24-b7d8-4989-9cd6-387772f40565",
                 "semanticId": {
                   "value": [
-                      "urn:net.catenax.vehicle:1.0.0#Parts"
+                      "urn:bamm:com.catenax:0.0.1#Traceability"
                   ]
-                }
+                },
+                "endpoints": [
+                  {
+                    "interface": "SUBMODEL-1.0RC02",
+                    "protocolInformation": {
+                      "endpointAddress": "edc://provider.connector:9191/offer-windchill/shells/882fc530-b69b-4707-95f6-5dbc5e9baaa8/aas/4a738a24-b7d8-4989-9cd6-387772f40565/submodel",
+                      "endpointProtocol": "IDS/ECLIPSE DATASPACE CONNECTOR",
+                      "endpointProtocolVersion": "0.0.1"
+                    }
+                  }
+                ]
               }
             ]
           },
@@ -1185,20 +1173,20 @@ components:
     minimal-submodel-descriptor:
       value:
         {
-          "idShort": "vehicle base details",
+          "idShort": "traceability-info",
           "identification": "4a738a24-b7d8-4989-9cd6-387772f40565",
           "semanticId": {
             "value": [
-                "urn:bamm:com.catenax.vehicle:0.1.1"
+                "urn:bamm:com.catenax:0.0.1#Traceability"
             ]
           },
           "endpoints": [
             {
-              "interface": "HTTP",
+              "interface": "SUBMODEL-1.0RC02",
               "protocolInformation": {
-                "endpointAddress": "https://catena-x.net/vehicle/basedetails/",
-                "endpointProtocol": "HTTPS",
-                "endpointProtocolVersion": "1.0"
+                "endpointAddress": "edc://provider.connector:9191/offer-windchill/shells/882fc530-b69b-4707-95f6-5dbc5e9baaa8/aas/4a738a24-b7d8-4989-9cd6-387772f40565/submodel",
+                "endpointProtocol": "IDS/ECLIPSE DATASPACE CONNECTOR",
+                "endpointProtocolVersion": "0.0.1"
               }
             }
           ]
@@ -1209,62 +1197,70 @@ components:
           "description": [
             {
               "language": "en",
-              "text": "Provides base vehicle information"
+              "text": "Provides traceability information"
             }
           ],
-          "idShort": "vehicle base details",
+          "idShort": "traceability-info",
           "identification": "4a738a24-b7d8-4989-9cd6-387772f40565",
           "semanticId": {
             "value": [
-                "urn:bamm:com.catenax.vehicle:0.1.1"
+                "urn:bamm:com.catenax:0.0.1#Traceability"
             ]
           },
           "endpoints": [
             {
-              "interface": "HTTP",
+              "interface": "SUBMODEL-1.0RC02",
               "protocolInformation": {
-                "endpointAddress": "https://catena-x.net/vehicle/basedetails/",
-                "endpointProtocol": "HTTPS",
-                "endpointProtocolVersion": "1.0"
+                "endpointAddress": "edc://provider.connector:9191/offer-windchill/shells/882fc530-b69b-4707-95f6-5dbc5e9baaa8/aas/4a738a24-b7d8-4989-9cd6-387772f40565/submodel",
+                "endpointProtocol": "IDS/ECLIPSE DATASPACE CONNECTOR",
+                "endpointProtocolVersion": "0.0.1"
               }
             }
           ]
         }
     submodel-descriptor-collection:
       value:
+        [
         {
-          "idShort": "vehicle base details",
+          "description": [
+            {
+              "language": "en",
+              "text": "Provides traceability information"
+            }
+          ],
+          "idShort": "traceability-info",
           "identification": "4a738a24-b7d8-4989-9cd6-387772f40565",
           "semanticId": {
             "value": [
-                "urn:bamm:com.catenax.vehicle:0.1.1"
+                "urn:bamm:com.catenax:0.0.1#Traceability"
             ]
           },
           "endpoints": [
             {
-              "interface": "HTTP",
+              "interface": "SUBMODEL-1.0RC02",
               "protocolInformation": {
-                "endpointAddress": "https://catena-x.net/vehicle/basedetails/",
-                "endpointProtocol": "HTTPS",
-                "endpointProtocolVersion": "1.0"
+                "endpointAddress": "edc://provider.connector:9191/offer-windchill/shells/882fc530-b69b-4707-95f6-5dbc5e9baaa8/aas/4a738a24-b7d8-4989-9cd6-387772f40565/submodel",
+                "endpointProtocol": "IDS/ECLIPSE DATASPACE CONNECTOR",
+                "endpointProtocolVersion": "0.0.1"
               }
             }
           ]
         }
+        ]
     lookup-shells-by-aas-identifier-query:
       value:
         [
             {
               "key" :   "globalAssetId",
-              "value" : "192fc530-c69b-3707-25f6-5dbc2e9baaa8"
+              "value" :  "urn:twin:net.catenax#3c7556f7-6956-4360-8036-d03e5a79c3c8"
             },
             {
-              "key": "engineserialid",
-              "value": "1239472980298312"
+              "key": "PartInstanceID",
+              "value": "24975539203421"
             },
             {
-              "key": "brakenumber",
-              "value": "123092"
+              "key": "VAN",
+              "value": "WEBFC102u30912"
             }
         ]
     lookup-shells-by-aas-identifier-response:
@@ -1276,11 +1272,7 @@ components:
       value:
         [
           {
-            "key": "engineserialid",
-            "value": "1239472980298312"
-          },
-          {
-            "key": "brakenumber",
-            "value": "123092"
+            "key": "PartInstanceID",
+            "value": "24975539203421"
           }
         ]

--- a/semantics/registry/src/main/resources/static/aas-registry-openapi.yaml
+++ b/semantics/registry/src/main/resources/static/aas-registry-openapi.yaml
@@ -493,6 +493,31 @@ paths:
           description: Asset identifier key-value-pairs deleted successfully
       x-semanticIds:
       - https://admin-shell.io/aas/API/DeleteAllAssetLinksById/1/0/RC02
+  /lookup/shells/query:
+    post:
+      tags:
+        - Registry and Discovery Interface
+      summary: Returns a list of Asset Administration Shell ids based on Asset identifier key-value-pairs.
+      operationId: GetAllAssetAdministrationShellIdsByQuery
+      requestBody:
+        description: Asset Administration Shell Descriptor object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ShellLookup'
+        required: true
+      responses:
+        "200":
+          description: Requested Asset Administration Shell ids
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Identifier'
+              examples:
+                complete:
+                  $ref: '#/components/examples/lookup-shells-by-aas-identifier-response'
 components:
   schemas:
     # The official spec does not support pagination right now. This is an addition.
@@ -780,6 +805,18 @@ components:
         status:
           type: integer
           description: The status code
+    ShellLookup:
+      type: object
+      required:
+        - query
+      properties:
+        query:
+          type: object
+          properties:
+            assetIds:
+              type: array
+              items:
+                $ref: '#/components/schemas/IdentifierKeyValuePair'
   securitySchemes:
     CatenaXOpenId:
       type: openIdConnect

--- a/semantics/registry/src/main/resources/static/aas-registry-openapi.yaml
+++ b/semantics/registry/src/main/resources/static/aas-registry-openapi.yaml
@@ -118,6 +118,37 @@ paths:
                   $ref: '#/components/examples/asset-administration-shell-descriptor-batch-result'
       x-semanticIds:
         - https://admin-shell.io/aas/API/PostAssetAdministrationShellDescriptor/1/0/RC02
+  /registry/shell-descriptors/fetch:
+    post:
+      tags:
+        - Registry and Discovery Interface
+      summary: Returns shell descriptors for the given identifications.
+      operationId: PostFetchAssetAdministrationShellDescriptor
+      requestBody:
+        description: Asset Administration Shell Descriptor object
+        content:
+          application/json:
+            schema:
+              type: array
+              minLength: 1
+              items:
+                $ref: '#/components/schemas/Identifier'
+            examples:
+              complete:
+                $ref: '#/components/examples/asset-administration-shell-descriptor-fetch-request'
+        required: true
+      responses:
+        "201":
+          description: Asset Administration Shell Descriptors
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetAdministrationShellDescriptorCollectionBase'
+              examples:
+                complete:
+                  $ref: '#/components/examples/asset-administration-shell-descriptor-fetch-result'
+      x-semanticIds:
+        - https://admin-shell.io/aas/API/PostAssetAdministrationShellDescriptor/1/0/RC02
   /registry/shell-descriptors/{aasIdentifier}:
     get:
       tags:
@@ -521,14 +552,10 @@ paths:
 components:
   schemas:
     # The official spec does not support pagination right now. This is an addition.
-    AssetAdministrationShellDescriptorCollection:
-      title: AssetAdministrationShellDescriptorCollection
+    AssetAdministrationShellDescriptorCollectionBase:
+      title: AssetAdministrationShellDescriptorCollectionBase
       required:
         - items
-        - totalItems
-        - currentPage
-        - totalPages
-        - itemCount
       type: object
       properties:
         items:
@@ -536,6 +563,17 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AssetAdministrationShellDescriptor'
+    AssetAdministrationShellDescriptorCollection:
+      title: AssetAdministrationShellDescriptorCollection
+      allOf:
+        - $ref: '#/components/schemas/AssetAdministrationShellDescriptorCollectionBase'
+      required:
+        - totalItems
+        - currentPage
+        - totalPages
+        - itemCount
+      type: object
+      properties:
         totalItems:
           title: Totalitems
           type: integer
@@ -551,6 +589,7 @@ components:
     AssetAdministrationShellDescriptor:
       required:
       - identification
+      - idShort
       type: object
       properties:
         administration:
@@ -671,8 +710,9 @@ components:
       required:
       - keys
       properties:
-        referredSemanticId:
-          $ref: '#/components/schemas/Reference'
+      # not supported for Catena-X
+      #  referredSemanticId:
+       #   $ref: '#/components/schemas/Reference'
         keys:
           type: array
           items:
@@ -727,8 +767,9 @@ components:
             type: string
             minLength: 1
             maxLength: 200
-          subjectId:
-            $ref: '#/components/schemas/Reference'
+          # not supported for Catena-X
+          # subjectId:
+            # $ref: '#/components/schemas/Reference'
           value:
             type: string
             minLength: 1
@@ -840,7 +881,7 @@ components:
           ],
           "globalAssetId": {
             "value": [
-                "VIN1230941209423423"
+                "192fc530-c69b-3707-25f6-5dbc2e9baaa8"
             ]
           },
           "idShort": "future concept x",
@@ -917,7 +958,7 @@ components:
               ],
               "globalAssetId": {
                 "value": [
-                    "VIN1230941209423423"
+                    "192fc530-c69b-3707-25f6-5dbc2e9baaa8"
                 ]
               },
               "idShort": "future concept x",
@@ -966,6 +1007,70 @@ components:
           "totalPages": 1,
           "itemCount": 2
         }
+    asset-administration-shell-descriptor-fetch-result:
+      value:
+        {
+          "items": [
+            {
+              "description": [
+                {
+                  "language": "en",
+                  "text": "The shell for a vehicle"
+                }
+              ],
+              "globalAssetId": {
+                "value": [
+                    "192fc530-c69b-3707-25f6-5dbc2e9baaa8"
+                ]
+              },
+              "idShort": "future concept x",
+              "identification": "882fc530-b69b-4707-95f6-5dbc5e9baaa8",
+              "specificAssetIds": [
+                {
+                  "key": "engineserialid",
+                  "value": "12309481209312"
+                }
+              ],
+              "submodelDescriptors": [
+                {
+                  "description": [
+                    {
+                      "language": "en",
+                      "text": "Provides base vehicle information"
+                    }
+                  ],
+                  "idShort": "vehicle base details",
+                  "identification": "4a738a24-b7d8-4989-9cd6-387772f40565",
+                  "semanticId": {
+                    "value": [
+                        "urn:bamm:com.catenax.vehicle:0.1.1"
+                    ]
+                  },
+                  "endpoints": [
+                    {
+                      "interface": "HTTP",
+                      "protocolInformation": {
+                        "endpointAddress": "https://catena-x.net/vehicle/basedetails/",
+                        "endpointProtocol": "HTTPS",
+                        "endpointProtocolVersion": "1.0"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "idShort": "future concept x",
+              "identification": "459842bf-3466-4eb6-8d95-ef0557e64883"
+            }
+          ]
+        }
+    asset-administration-shell-descriptor-fetch-request:
+       value:
+         [
+          "882fc530-b69b-4707-95f6-5dbc5e9baaa8",
+          "459842bf-3466-4eb6-8d95-ef0557e64883"
+         ]
     asset-administration-shell-descriptor-batch:
        value:
         [
@@ -989,8 +1094,8 @@ components:
             },
             "specificAssetIds": [
               {
-                "key": "vin1",
-                "value": "valueforvin1"
+                "key": "PartId",
+                "value": "f10ujf2lkcb"
               },
               {
                 "key": "enginenumber1",
@@ -1151,7 +1256,7 @@ components:
         [
             {
               "key" :   "globalAssetId",
-              "value" : "VIN1230941209423423"
+              "value" : "192fc530-c69b-3707-25f6-5dbc2e9baaa8"
             },
             {
               "key": "engineserialid",

--- a/semantics/registry/src/test/java/net/catenax/semantics/registry/AssetAdministrationShellApiTest.java
+++ b/semantics/registry/src/test/java/net/catenax/semantics/registry/AssetAdministrationShellApiTest.java
@@ -881,6 +881,62 @@ public class AssetAdministrationShellApiTest {
                     .andExpect(jsonPath("$", hasSize(2)))
                     .andExpect(jsonPath("$", containsInAnyOrder(getId(firstShellPayload), getId(secondShellPayload))));
         }
+
+        @Test
+        public void testFetchShellsByNoIdentificationsExpectEmptyResult() throws Exception {
+            mvc.perform(
+                            MockMvcRequestBuilders
+                                    .post(SHELL_BASE_PATH + "/fetch")
+                                    .content(toJson(emptyArrayNode()))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
+                    )
+                    .andDo(MockMvcResultHandlers.print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.items", hasSize(0)));
+        }
+
+        @Test
+        public void testFetchShellsByMultipleIdentificationsExpectSuccessExpectSuccess() throws Exception {
+
+            ObjectNode shellPayload1 = createShell(false);
+            performShellCreateRequest(toJson(shellPayload1));
+
+            ObjectNode shellPayload2 = createShell(false);
+            performShellCreateRequest(toJson(shellPayload2));
+
+            ArrayNode fetchOneShellsById =  emptyArrayNode().add(getId(shellPayload1));
+            mvc.perform(
+                            MockMvcRequestBuilders
+                                    .post(SHELL_BASE_PATH + "/fetch")
+                                    .content(toJson(fetchOneShellsById))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
+                    )
+                    .andDo(MockMvcResultHandlers.print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.items", hasSize(1)))
+                    // ensure that only three results match
+                    .andExpect(jsonPath("$.items[*].identification", hasItem(getId(shellPayload1))));
+
+
+            ArrayNode fetchTwoShellsById =  emptyArrayNode()
+                    .add(getId(shellPayload1))
+                    .add(getId(shellPayload2));
+            mvc.perform(
+                            MockMvcRequestBuilders
+                                    .post(SHELL_BASE_PATH + "/fetch")
+                                    .content(toJson(fetchTwoShellsById))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
+                    )
+                    .andDo(MockMvcResultHandlers.print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.items", hasSize(2)))
+                    // ensure that only three results match
+                    .andExpect(jsonPath("$.items[*].identification",
+                            hasItems(getId(shellPayload1), getId(shellPayload2)) ));
+        }
     }
 
 

--- a/semantics/registry/src/test/java/net/catenax/semantics/registry/AssetAdministrationShellApiTest.java
+++ b/semantics/registry/src/test/java/net/catenax/semantics/registry/AssetAdministrationShellApiTest.java
@@ -776,7 +776,6 @@ public class AssetAdministrationShellApiTest {
                     .andExpect(jsonPath("$",  contains(getId(shellPayload))));
         }
 
-
         @Test
         public void testFindExternalShellIdsWithoutProvidingQueryParametersExpectEmptyResult() throws Exception {
             // prepare the data set
@@ -845,6 +844,43 @@ public class AssetAdministrationShellApiTest {
                     .andExpect(jsonPath("$", hasSize(5)));
         }
 
+        @Test
+        public void testFindExternalShellIdsBySpecificAssetIdsWithAnyMatchExpectSuccess() throws Exception {
+            // the keyPrefix ensures that this test can run against a persistent database multiple times
+            String keyPrefix = UUID.randomUUID().toString();
+            ObjectNode commonAssetId = specificAssetId(keyPrefix + "commonAssetIdKey", "commonAssetIdValue");
+            // first shell
+            ObjectNode firstShellPayload = createBaseIdPayload("sampleForQuery", "idShortSampleForQuery");
+            firstShellPayload.set("specificAssetIds", emptyArrayNode()
+                    .add(specificAssetId(keyPrefix + "findExternalShellIdQueryKey_1", "value_1")));
+            performShellCreateRequest(toJson(firstShellPayload));
+
+            // second shell
+            ObjectNode secondShellPayload = createBaseIdPayload("sampleForQuery", "idShortSampleForQuery");
+            secondShellPayload.set("specificAssetIds", emptyArrayNode()
+                    .add(specificAssetId(keyPrefix + "findExternalShellIdQueryKey_2", "value_2")));
+            performShellCreateRequest(toJson(secondShellPayload));
+
+            // query to retrieve any match
+            JsonNode anyMatchAueryByAssetIds = mapper.createObjectNode().set("query", mapper.createObjectNode()
+                            .set("assetIds",  emptyArrayNode()
+                                    .add(specificAssetId(keyPrefix + "findExternalShellIdQueryKey_1", "value_1"))
+                                    .add(specificAssetId(keyPrefix + "findExternalShellIdQueryKey_2", "value_2"))
+                                    .add(commonAssetId))
+                   );
+
+            mvc.perform(
+                            MockMvcRequestBuilders
+                                    .post(LOOKUP_SHELL_BASE_PATH + "/query")
+                                    .content(toJson(anyMatchAueryByAssetIds))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .with(jwt())
+                    )
+                    .andDo(MockMvcResultHandlers.print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$", hasSize(2)))
+                    .andExpect(jsonPath("$", containsInAnyOrder(getId(firstShellPayload), getId(secondShellPayload))));
+        }
     }
 
 


### PR DESCRIPTION
This PR introduces two new API endpoints to the Registry.

POST /lookup/shells/query

Accepts an array of assetIds and returns all shell ids that match **any** of the assetIds.

POST /registry/shell-descriptors/fetch

Accepts an array of shellIds and returns all matching shell-descriptors in complete form.
