### PR TITLE
Main: spring boot upgrade CVE fix

### DIFF
--- a/semantics/adapter/pom.xml
+++ b/semantics/adapter/pom.xml
@@ -73,6 +73,10 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jetty</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>

--- a/semantics/pom.xml
+++ b/semantics/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.6</version> <!-- need to be repeated in properties section for technical purposes -->
+        <version>2.6.5</version> <!-- need to be repeated in properties section for technical purposes -->
         <relativePath/> <!-- lookup parent from repository and not the filesystem -->
     </parent>
 
@@ -55,9 +55,9 @@
 
 		<!-- version properties -->
 		<!-- framework and base stuff -->
-		<spring.boot.version>2.5.6</spring.boot.version>
-		<spring.cloud.version>2020.0.3</spring.cloud.version>
-		<spring.version>5.3.12</spring.version>
+		<spring.boot.version>2.6.5</spring.boot.version>
+		<spring.cloud.version>2021.0.1</spring.cloud.version>
+		<spring.version>5.3.18</spring.version>
 		<spring.feign.version>3.0.5</spring.feign.version>
 		<springdoc.version>1.6.6</springdoc.version>
 		<springfox.version>2.9.2</springfox.version>

--- a/semantics/pom.xml
+++ b/semantics/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.5</version> <!-- need to be repeated in properties section for technical purposes -->
+        <version>2.5.6</version> <!-- need to be repeated in properties section for technical purposes -->
         <relativePath/> <!-- lookup parent from repository and not the filesystem -->
     </parent>
 
@@ -55,9 +55,9 @@
 
 		<!-- version properties -->
 		<!-- framework and base stuff -->
-		<spring.boot.version>2.6.5</spring.boot.version>
-		<spring.cloud.version>2021.0.1</spring.cloud.version>
-		<spring.version>5.3.18</spring.version>
+		<spring.boot.version>2.5.6</spring.boot.version>
+		<spring.cloud.version>2020.0.3</spring.cloud.version>
+		<spring.version>5.3.12</spring.version>
 		<spring.feign.version>3.0.5</spring.feign.version>
 		<springdoc.version>1.6.6</springdoc.version>
 		<springfox.version>2.9.2</springfox.version>
@@ -174,6 +174,10 @@
 					<exclusion>
 						<groupId>org.springframework.boot</groupId>
 						<artifactId>spring-boot-starter-logging</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-starter-tomcat</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>

--- a/semantics/registry/pom.xml
+++ b/semantics/registry/pom.xml
@@ -57,6 +57,10 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jetty</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>

--- a/semantics/semantic-hub/pom.xml
+++ b/semantics/semantic-hub/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jetty</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>


### PR DESCRIPTION
This PR mitigates the critical CVE https://tanzu.vmware.com/security/cve-2022-22965.

There is currently no new Spring Boot version that contains a fix. I replaced tomcat with jetty to mitigate the CVE.

I also wanted to upgrade to the latest Spring Boot version, but there is a breaking change in Spring, that breaks spring-fox used in the adapter project. Spring fox is deprecated, we need to replace it in the adapter project with spring-doc, as we did for registry and semantic hub.