### PR TITLE
Fix compile issues in API wrapper

### DIFF
--- a/eclipsedataspaceconnector/api-wrapper/launchers/api-wrapper/src/main/java/org/eclipse/dataspaceconnector/apiwrapper/EdcCallbackController.java
+++ b/eclipsedataspaceconnector/api-wrapper/launchers/api-wrapper/src/main/java/org/eclipse/dataspaceconnector/apiwrapper/EdcCallbackController.java
@@ -22,7 +22,7 @@ public class EdcCallbackController {
 
     @POST
     public void receiveEdcCallback(EndpointDataReference dataReference) {
-        endpointDataReferenceStore.put(dataReference.getContractId(), dataReference);
-        monitor.debug("Endpoint Data Reference received and stored for agreement: " + dataReference.getContractId());
+        endpointDataReferenceStore.put(dataReference.getId(), dataReference);
+        monitor.debug("Endpoint Data Reference received and stored for agreement: " + dataReference.getId());
     }
 }

--- a/eclipsedataspaceconnector/api-wrapper/launchers/api-wrapper/src/main/java/org/eclipse/dataspaceconnector/apiwrapper/connector/sdk/service/HttpProxyService.java
+++ b/eclipsedataspaceconnector/api-wrapper/launchers/api-wrapper/src/main/java/org/eclipse/dataspaceconnector/apiwrapper/connector/sdk/service/HttpProxyService.java
@@ -26,7 +26,7 @@ public class HttpProxyService {
     }
 
     public String sendGETRequest(EndpointDataReference dataReference, String subUrl, MultivaluedMap<String, String> parameters) throws IOException {
-        var url = getUrl(dataReference.getAddress(), subUrl, parameters);
+        var url = getUrl(dataReference.getEndpoint(), subUrl, parameters);
 
         var request = new Request.Builder()
                 .url(url)
@@ -37,7 +37,7 @@ public class HttpProxyService {
     }
 
     public String sendPOSTRequest(EndpointDataReference dataReference, String subUrl, MultivaluedMap<String, String> parameters, String data, MediaType mediaType) throws IOException {
-        var url = getUrl(dataReference.getAddress(), subUrl, parameters);
+        var url = getUrl(dataReference.getEndpoint(), subUrl, parameters);
 
         var request = new Request.Builder()
                 .url(url)


### PR DESCRIPTION
The API wrapper does not compile with the versions from EDC main branch: https://github.com/eclipse-dataspaceconnector/DataSpaceConnector. 

This PR fixes the compile issues.
@florianrusch-zf  i'am not sure if the `getContractId` can be replaced by `getId()`.
Do you have any insights about the EDC internals?