### PR TITLE
change /model endpoint to accept text/plain

### DIFF
--- a/semantics/semantic-hub/src/main/java/net/catenax/semantics/hub/AspectModelService.java
+++ b/semantics/semantic-hub/src/main/java/net/catenax/semantics/hub/AspectModelService.java
@@ -22,10 +22,10 @@ import net.catenax.semantics.hub.api.ModelsApiDelegate;
 import net.catenax.semantics.hub.bamm.BammHelper;
 import net.catenax.semantics.hub.domain.ModelPackageStatus;
 import net.catenax.semantics.hub.domain.ModelPackageUrn;
-import net.catenax.semantics.hub.model.NewSemanticModel;
 import net.catenax.semantics.hub.model.SemanticModel;
 import net.catenax.semantics.hub.model.SemanticModelList;
 import net.catenax.semantics.hub.model.SemanticModelStatus;
+import net.catenax.semantics.hub.model.SemanticModelType;
 import net.catenax.semantics.hub.persistence.PersistenceLayer;
 
 public class AspectModelService implements ModelsApiDelegate {
@@ -82,8 +82,8 @@ public class AspectModelService implements ModelsApiDelegate {
    }
 
    @Override
-   public ResponseEntity<SemanticModel> createModelWithUrn( final NewSemanticModel newModel ) {
-      final SemanticModel resultingModel = persistenceLayer.save( newModel );
+   public ResponseEntity<SemanticModel> createModelWithUrn(final SemanticModelType type, final String newModel, final SemanticModelStatus status ) {
+      final SemanticModel resultingModel = persistenceLayer.save( type, newModel, status );
       return new ResponseEntity<>( resultingModel, HttpStatus.OK );
    }
 
@@ -128,8 +128,8 @@ public class AspectModelService implements ModelsApiDelegate {
    }
 
    @Override
-   public ResponseEntity<SemanticModel> modifyModel( final NewSemanticModel newModel ) {
-      final SemanticModel resultingModel = persistenceLayer.save( newModel );
+   public ResponseEntity<SemanticModel> modifyModel( final SemanticModelType type, final String newModel, final SemanticModelStatus status  ) {
+      final SemanticModel resultingModel = persistenceLayer.save( type, newModel, status );
       return new ResponseEntity<>( resultingModel, HttpStatus.OK );
    }
 

--- a/semantics/semantic-hub/src/main/java/net/catenax/semantics/hub/persistence/PersistenceLayer.java
+++ b/semantics/semantic-hub/src/main/java/net/catenax/semantics/hub/persistence/PersistenceLayer.java
@@ -21,9 +21,10 @@ import javax.annotation.Nullable;
 import io.openmanufacturing.sds.aspectmodel.urn.AspectModelUrn;
 import net.catenax.semantics.hub.domain.ModelPackageStatus;
 import net.catenax.semantics.hub.domain.ModelPackageUrn;
-import net.catenax.semantics.hub.model.NewSemanticModel;
 import net.catenax.semantics.hub.model.SemanticModel;
 import net.catenax.semantics.hub.model.SemanticModelList;
+import net.catenax.semantics.hub.model.SemanticModelStatus;
+import net.catenax.semantics.hub.model.SemanticModelType;
 
 /**
  * Interface to any model persistency implementation
@@ -46,7 +47,7 @@ public interface PersistenceLayer {
 
    SemanticModel getModel( AspectModelUrn urn );
 
-   SemanticModel save( NewSemanticModel model );
+   SemanticModel save(SemanticModelType type, String newModel, SemanticModelStatus status);
 
    String getModelDefinition( AspectModelUrn urn );
 

--- a/semantics/semantic-hub/src/main/resources/static/semantic-hub-openapi.yaml
+++ b/semantics/semantic-hub/src/main/resources/static/semantic-hub-openapi.yaml
@@ -67,15 +67,25 @@ paths:
       tags:
         - SemanticHub
       operationId: createModelWithUrn
+      parameters:
+      - in: query
+        name: status
+        schema:
+          $ref: '#/components/schemas/SemanticModelStatus'
+      - in: query
+        name: type
+        required: true
+        schema:
+          $ref: '#/components/schemas/SemanticModelType'
       requestBody:
         description: >-
           The request body contains all necessary properties to create a new
           model entry.
         required: true
         content:
-          application/json:
+          text/plain:
             schema:
-              $ref: '#/components/schemas/NewSemanticModel'
+              type: string
       responses:
         '201':
           $ref: '#/components/responses/SemanticModel'
@@ -89,14 +99,24 @@ paths:
       tags:
         - SemanticHub
       operationId: modifyModel
+      parameters:
+        - in: query
+          name: status
+          schema:
+            $ref: '#/components/schemas/SemanticModelStatus'
+        - in: query
+          name: type
+          required: true
+          schema:
+            $ref: '#/components/schemas/SemanticModelType'
       requestBody:
         description: >-
           The request body contains the updated model.
         required: true
         content:
-          application/json:
+          text/plain:
             schema:
-              $ref: '#/components/schemas/NewSemanticModel'
+              type: string
       responses:
         '200':
           $ref: '#/components/responses/SemanticModel'

--- a/semantics/semantic-hub/src/test/java/net/catenax/semantics/hub/ModelsApiFilterTest.java
+++ b/semantics/semantic-hub/src/test/java/net/catenax/semantics/hub/ModelsApiFilterTest.java
@@ -215,9 +215,11 @@ public class ModelsApiFilterTest {
       mvc.perform(
                MockMvcRequestBuilders
                      .post( "/api/v1/models" )
+                     .queryParam("status", status)
+                     .queryParam("type", "BAMM")
                      .accept( MediaType.APPLICATION_JSON )
-                     .contentType( MediaType.APPLICATION_JSON )
-                     .content( TestUtils.createNewModelRequestJson( modelWithReferenceToTraceability, status ) )
+                     .contentType( MediaType.TEXT_PLAIN )
+                     .content(modelWithReferenceToTraceability)
                      .with(jwt())
          )
          .andDo( MockMvcResultHandlers.print() )

--- a/semantics/semantic-hub/src/test/java/net/catenax/semantics/hub/ModelsApiPaginationTest.java
+++ b/semantics/semantic-hub/src/test/java/net/catenax/semantics/hub/ModelsApiPaginationTest.java
@@ -16,7 +16,6 @@
 
 package net.catenax.semantics.hub;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,15 +24,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.util.List;
 
+import static net.catenax.semantics.hub.TestUtils.post;
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -62,7 +59,7 @@ public class ModelsApiPaginationTest {
 
       prefixes.forEach(urnPrefix -> {
          try {
-            mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix, "DRAFT")  ))
+            mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix), "DRAFT")  )
                     .andDo( MockMvcResultHandlers.print() )
                     .andExpect( status().isOk() );
          } catch (Exception e) {
@@ -157,14 +154,6 @@ public class ModelsApiPaginationTest {
               .andExpect( jsonPath( "$.totalPages", equalTo(2) ) )
               .andExpect( jsonPath( "$.itemCount", equalTo( 3 ) ) )
               .andExpect( status().isOk() );
-   }
-
-   private MockHttpServletRequestBuilder post(String payload ) {
-      return MockMvcRequestBuilders.post( "/api/v1/models" )
-              .accept( MediaType.APPLICATION_JSON )
-              .contentType( MediaType.APPLICATION_JSON )
-              .content( payload )
-              .with(jwt());
    }
 
    private static String toMovementUrn(String urn){

--- a/semantics/semantic-hub/src/test/java/net/catenax/semantics/hub/ModelsApiTest.java
+++ b/semantics/semantic-hub/src/test/java/net/catenax/semantics/hub/ModelsApiTest.java
@@ -16,6 +16,9 @@
 
 package net.catenax.semantics.hub;
 
+import static net.catenax.semantics.hub.TestUtils.delete;
+import static net.catenax.semantics.hub.TestUtils.post;
+import static net.catenax.semantics.hub.TestUtils.put;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
@@ -34,7 +37,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
@@ -73,7 +75,7 @@ public class ModelsApiTest {
    public void testGetModelsExpectSuccess() throws Exception {
       String urnPrefix = "urn:bamm:net.catenax:1.0.0#";
       mvc.perform(
-               post( TestUtils.createValidModelRequest(urnPrefix, "DRAFT")  )
+               post( TestUtils.createValidModelRequest(urnPrefix),"DRAFT")
          )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( status().isOk() );
@@ -99,7 +101,7 @@ public class ModelsApiTest {
    public void testSaveValidModelExpectSuccess() throws Exception {
       String urnPrefix = "urn:bamm:net.catenax.valid.save:2.0.0#";
       mvc.perform(
-               post( TestUtils.createValidModelRequest(urnPrefix, "RELEASED") )
+               post( TestUtils.createValidModelRequest(urnPrefix),"RELEASED")
          )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( jsonPath( "$.urn", is( toMovementUrn(urnPrefix) ) ) )
@@ -112,7 +114,7 @@ public class ModelsApiTest {
 
    @Test
    public void testSaveInvalidModelExpectSuccess() throws Exception {
-      String insertModelJson = "{\"model\": \"@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:1.0.0#> .\\n @prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:1.0.0#> .\\n @prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:1.0.0#> .\\n @prefix unit: <urn:bamm:io.openmanufacturing:unit:1.0.0#> .\\n @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\\n @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\\n @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\\n @prefix : <urn:bamm:net.catenax:1.0.0#> .\\n \\n :Movement a bamm:Aspect;\\n bamm:name \\\"Movement\\\";\\n bamm:preferredName \\\"Movement\\\"@en;\\n bamm:description \\\"Aspect for movement information\\\"@en;\\n bamm:propertiesX (:isMoving :speedLimitWarning :position);\\n bamm:operations ().\\n :isMoving a bamm:Property;\\n bamm:name \\\"isMoving\\\";\\n bamm:preferredName \\\"Moving\\\"@en;\\n bamm:description \\\"Flag indicating whether the asset is currently moving\\\"@en;\\n bamm:characteristic bamm-c:Boolean.\\n :speedLimitWarning a bamm:Property;\\n bamm:name \\\"speedLimitWarning\\\";\\n bamm:preferredName \\\"Speed Limit Warning\\\"@en;\\n bamm:description \\\"Indicates if the speed limit is adhered to.\\\"@en;\\n bamm:characteristic :TrafficLight.\\n :position a bamm:Property;\\n bamm:name \\\"position\\\";\\n bamm:preferredName \\\"Position\\\"@en;\\n bamm:description \\\"Indicates a position\\\"@en;\\n bamm:characteristic :SpatialPositionCharacteristic.\\n :TrafficLight a bamm-c:Enumeration;\\n bamm:name \\\"TrafficLight\\\";\\n bamm:preferredName \\\"Warning Level\\\"@en;\\n bamm:description \\\"Represents if speed of position change is within specification (green), within tolerance (yellow), or outside specification (red).\\\"@en;\\n bamm:dataType xsd:string;\\n bamm-c:values (\\\"green\\\" \\\"yellow\\\" \\\"red\\\").\\n :SpatialPosition a bamm:Entity;\\n bamm:name \\\"SpatialPosition\\\";\\n bamm:preferredName \\\"Spatial Position\\\"@en;\\n bamm:description \\\"Position in space, described along three axis, with the third axis optional, if all positions are in a plane.\\\"@en;\\n bamm:properties (:x :y :z).\\n :x a bamm:Property;\\n bamm:name \\\"x\\\";\\n bamm:preferredName \\\"x\\\"@en;\\n bamm:description \\\"x coordinate in space\\\"@en;\\n bamm:characteristic :Coordinate.\\n :y a bamm:Property;\\n bamm:name \\\"y\\\";\\n bamm:preferredName \\\"y\\\"@en;\\n bamm:description \\\"y coordinate in space\\\"@en;\\n bamm:characteristic :Coordinate.\\n :z a bamm:Property;\\n bamm:name \\\"z\\\";\\n bamm:preferredName \\\"z\\\"@en;\\n bamm:description \\\"z coordinate in space\\\"@en;\\n bamm:characteristic :Coordinate;\\n bamm:optional \\\"true\\\"^^xsd:boolean.\\n :Coordinate a bamm-c:Measurement;\\n bamm:name \\\"Coordinate\\\";\\n bamm:preferredName \\\"Coordinate\\\"@en;\\n bamm:description \\\"Represents a coordinate along an axis in space.\\\"@en;\\n bamm:dataType xsd:float;\\n bamm-c:unit unit:metre.\\n :SpatialPositionCharacteristic a bamm-c:SingleEntity;\\n bamm:name \\\"SpatialPositionCharacteristic\\\";\\n bamm:preferredName \\\"Spatial Position Characteristic\\\"@en;\\n bamm:description \\\"Represents a single position in space with optional z coordinate.\\\"@en;\\n bamm:dataType :SpatialPosition.\\n\",\"type\": \"BAMM\"}";
+      String insertModelJson = "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:1.0.0#> .\n @prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:1.0.0#> .\n @prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:1.0.0#> .\n @prefix unit: <urn:bamm:io.openmanufacturing:unit:1.0.0#> .\n @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n @prefix : <urn:bamm:net.catenax:1.0.0#> .\n \n :Movement a bamm:Aspect;\n bamm:name \"Movement\";\n bamm:preferredName \"Movement\"@en;\n bamm:description \"Aspect for movement information\"@en;\n bamm:propertiesX (:isMoving :speedLimitWarning :position);\n bamm:operations ().\n :isMoving a bamm:Property;\n bamm:name \"isMoving\";\n bamm:preferredName \"Moving\"@en;\n bamm:description \"Flag indicating whether the asset is currently moving\"@en;\n bamm:characteristic bamm-c:Boolean.\n :speedLimitWarning a bamm:Property;\n bamm:name \"speedLimitWarning\";\n bamm:preferredName \"Speed Limit Warning\"@en;\n bamm:description \"Indicates if the speed limit is adhered to.\"@en;\n bamm:characteristic :TrafficLight.\n :position a bamm:Property;\n bamm:name \"position\";\n bamm:preferredName \"Position\"@en;\n bamm:description \"Indicates a position\"@en;\n bamm:characteristic :SpatialPositionCharacteristic.\n :TrafficLight a bamm-c:Enumeration;\n bamm:name \"TrafficLight\";\n bamm:preferredName \"Warning Level\"@en;\n bamm:description \"Represents if speed of position change is within specification (green), within tolerance (yellow), or outside specification (red).\"@en;\n bamm:dataType xsd:string;\n bamm-c:values (\"green\" \"yellow\" \"red\").\n :SpatialPosition a bamm:Entity;\n bamm:name \"SpatialPosition\";\n bamm:preferredName \"Spatial Position\"@en;\n bamm:description \"Position in space, described along three axis, with the third axis optional, if all positions are in a plane.\"@en;\n bamm:properties (:x :y :z).\n :x a bamm:Property;\n bamm:name \"x\";\n bamm:preferredName \"x\"@en;\n bamm:description \"x coordinate in space\"@en;\n bamm:characteristic :Coordinate.\n :y a bamm:Property;\n bamm:name \"y\";\n bamm:preferredName \"y\"@en;\n bamm:description \"y coordinate in space\"@en;\n bamm:characteristic :Coordinate.\n :z a bamm:Property;\n bamm:name \"z\";\n bamm:preferredName \"z\"@en;\n bamm:description \"z coordinate in space\"@en;\n bamm:characteristic :Coordinate;\n bamm:optional \"true\"^^xsd:boolean.\n :Coordinate a bamm-c:Measurement;\n bamm:name \"Coordinate\";\n bamm:preferredName \"Coordinate\"@en;\n bamm:description \"Represents a coordinate along an axis in space.\"@en;\n bamm:dataType xsd:float;\n bamm-c:unit unit:metre.\n :SpatialPositionCharacteristic a bamm-c:SingleEntity;\n bamm:name \"SpatialPositionCharacteristic\";\n bamm:preferredName \"Spatial Position Characteristic\"@en;\n bamm:description \"Represents a single position in space with optional z coordinate.\"@en;\n bamm:dataType :SpatialPosition.";
 
       mvc.perform(post( insertModelJson ))
          .andDo( MockMvcResultHandlers.print() )
@@ -125,7 +127,7 @@ public class ModelsApiTest {
    public void testGenerateJsonSchemaExpectSuccess() throws Exception {
       String urnPrefix = "urn:bamm:net.catenax.model.status.transition:2.0.0#";
       mvc.perform(
-               post( TestUtils.createValidModelRequest(urnPrefix, "RELEASED") )
+               post( TestUtils.createValidModelRequest(urnPrefix),"RELEASED")
          )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( status().isOk() );
@@ -156,7 +158,7 @@ public class ModelsApiTest {
    @Test
    public void testGenerateOpenApiEndpointSpecExpectSuccess() throws Exception {
       String urnPrefix = "urn:bamm:net.catenax.testopenapi:1.0.0#";
-      mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix, "DRAFT") ))
+      mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix),"DRAFT") )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( status().isOk() );
 
@@ -173,7 +175,7 @@ public class ModelsApiTest {
    @Test
    public void testExampleGenerateExamplePayloadJsonExpectSuccess() throws Exception {
       String urnPrefix = "urn:bamm:net.catenax.testjsonschema:2.0.0#";
-      mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix, "DRAFT") )
+      mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix),"DRAFT")
                       .with(jwt()))
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( status().isOk() );
@@ -201,7 +203,7 @@ public class ModelsApiTest {
       // this will fail because traceability does not exist yet
       String modelWithReferenceToTraceability = TestUtils.loadModelFromResources(
             TestUtils.MODEL_WITH_REFERENCE_TO_TRACEABILITY_MODEL_PATH );
-      mvc.perform( post( TestUtils.createNewModelRequestJson( modelWithReferenceToTraceability, "DRAFT" ) ) )
+      mvc.perform( post( modelWithReferenceToTraceability,"DRAFT" ) )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( status().isBadRequest() )
          .andExpect( jsonPath( "$.error.message", is( "Validation failed." ) ) )
@@ -209,14 +211,14 @@ public class ModelsApiTest {
                containsString( "urn:bamm:com.catenax.traceability:0.1.1#PartStaticDataCharacteristic" ) ) );
 
       // save the traceability aspect model
-      String traceability = TestUtils.loadModelFromResources(
+      String traceabilityModel = TestUtils.loadModelFromResources(
             TestUtils.TRACEABILITY_MODEL_PATH );
-      mvc.perform( post( TestUtils.createNewModelRequestJson( traceability, "DRAFT" ) ) )
+      mvc.perform( post( traceabilityModel, "DRAFT" ) )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( status().isOk() );
 
       // save again the model with external reference and validate the result
-      mvc.perform( post( TestUtils.createNewModelRequestJson( modelWithReferenceToTraceability, "DRAFT" ) ) )
+      mvc.perform( post(modelWithReferenceToTraceability, "DRAFT" ) )
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( status().isOk() );
 
@@ -270,7 +272,7 @@ public class ModelsApiTest {
          String urnPrefix = "urn:bamm:net.catenax.model.status.transition.post:2.0.0#";
 
          // draft state, deletes and modifications are allowed
-         mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix, "DRAFT") ))
+         mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix),"DRAFT") )
                  .andDo( MockMvcResultHandlers.print() )
                  .andExpect(status().isOk());
 
@@ -278,12 +280,12 @@ public class ModelsApiTest {
                  .andDo( MockMvcResultHandlers.print() )
                  .andExpect(status().isNoContent());
 
-         mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix, "DRAFT") ))
+         mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix),"DRAFT") )
                  .andDo( MockMvcResultHandlers.print() )
                  .andExpect(status().isOk());
 
          // transition from draft to release is allowed, delete is not allowed
-         mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix, "RELEASED") ))
+         mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix),"RELEASED") )
                  .andDo( MockMvcResultHandlers.print() )
                  .andExpect(status().isOk());
 
@@ -294,14 +296,14 @@ public class ModelsApiTest {
                          "The package urn:bamm:net.catenax.model.status.transition.post:2.0.0# is already in status RELEASED and cannot be deleted." ) ) );
 
          // transition from released to draft is not allowed
-         mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix, "DRAFT")))
+         mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix),"DRAFT") )
                  .andExpect( jsonPath( "$.error.message", is(
                          "The package urn:bamm:net.catenax.model.status.transition.post:2.0.0# is already in status RELEASED and cannot be modified. Only a transition to DEPRECATED is possible." ) ) )
                  .andExpect( status().isBadRequest() );
 
          // transition from released to deprecated is allowed
          mvc.perform(
-                         post( TestUtils.createValidModelRequest(urnPrefix, "DEPRECATED") )
+                         post( TestUtils.createValidModelRequest(urnPrefix),"DEPRECATED")
                  )
                  .andDo( MockMvcResultHandlers.print() )
                  .andExpect(status().isOk());
@@ -318,7 +320,7 @@ public class ModelsApiTest {
          String urnPrefix = "urn:bamm:net.catenax.model.status.transition.put:2.0.0#";
 
          // draft state, deletes and modifications are allowed
-         mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix, "DRAFT") ))
+         mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix),"DRAFT") )
                  .andDo( MockMvcResultHandlers.print() )
                  .andExpect(status().isOk());
 
@@ -326,12 +328,12 @@ public class ModelsApiTest {
                  .andDo( MockMvcResultHandlers.print() )
                  .andExpect(status().isNoContent());
 
-         mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix, "DRAFT") ))
+         mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix), "DRAFT") )
                  .andDo( MockMvcResultHandlers.print() )
                  .andExpect(status().isOk());
 
          // transition from draft to release is allowed, delete is not allowed
-         mvc.perform(put( TestUtils.createValidModelRequest(urnPrefix, "RELEASED")))
+         mvc.perform(put( TestUtils.createValidModelRequest(urnPrefix),"RELEASED"))
                  .andDo( MockMvcResultHandlers.print() )
                  .andExpect(status().isOk());
 
@@ -342,13 +344,13 @@ public class ModelsApiTest {
                          "The package urn:bamm:net.catenax.model.status.transition.put:2.0.0# is already in status RELEASED and cannot be deleted." ) ) );
 
          // transition from released to draft is not allowed
-         mvc.perform(put( TestUtils.createValidModelRequest(urnPrefix, "DRAFT") ))
+         mvc.perform(put( TestUtils.createValidModelRequest(urnPrefix), "DRAFT") )
                  .andExpect( jsonPath( "$.error.message", is(
                          "The package urn:bamm:net.catenax.model.status.transition.put:2.0.0# is already in status RELEASED and cannot be modified. Only a transition to DEPRECATED is possible." ) ) )
                  .andExpect( status().isBadRequest() );
 
          // transition from released to deprecated is allowed
-         mvc.perform(put( TestUtils.createValidModelRequest(urnPrefix, "DEPRECATED") ))
+         mvc.perform(put( TestUtils.createValidModelRequest(urnPrefix),"DEPRECATED") )
                  .andDo( MockMvcResultHandlers.print() )
                  .andExpect(status().isOk());
 
@@ -362,15 +364,15 @@ public class ModelsApiTest {
       public void testDependentModelTransition() throws Exception {
         String urnPrefix = "urn:bamm:net.catenax.model.status.transitionWithDependency:1.0.0#";
 
-        mvc.perform(post( TestUtils.createModelDependency("DRAFT") ))
+        mvc.perform(post( TestUtils.createModelDependency(), "DRAFT" ))
             .andDo( MockMvcResultHandlers.print() )
             .andExpect(status().isOk());
 
-        mvc.perform(post( TestUtils.createDependentModel(urnPrefix, "DRAFT") ))
+        mvc.perform(post( TestUtils.createDependentModel(urnPrefix), "DRAFT") )
             .andDo( MockMvcResultHandlers.print() )
             .andExpect(status().isOk());
 
-        mvc.perform(put( TestUtils.createDependentModel(urnPrefix, "RELEASED") ))
+        mvc.perform(put( TestUtils.createDependentModel(urnPrefix), "RELEASED") )
             .andDo( MockMvcResultHandlers.print() )
             .andExpect(jsonPath( "$.error.message", is(
                 "It is not allowed to release an aspect that has dependencies in DRAFT state." ) ) );
@@ -379,28 +381,5 @@ public class ModelsApiTest {
 
    private static String toMovementUrn(String urn){
       return urn + "Movement";
-   }
-
-   private MockHttpServletRequestBuilder post( String payload ) {
-      return MockMvcRequestBuilders.post( "/api/v1/models" )
-                                   .accept( MediaType.APPLICATION_JSON )
-                                   .contentType( MediaType.APPLICATION_JSON )
-                                   .content( payload )
-                                   .with(jwt());
-   }
-
-   private MockHttpServletRequestBuilder put( String payload ) {
-      return MockMvcRequestBuilders.put( "/api/v1/models" )
-              .accept( MediaType.APPLICATION_JSON )
-              .contentType( MediaType.APPLICATION_JSON )
-              .content( payload )
-              .with(jwt());
-   }
-
-   private MockHttpServletRequestBuilder delete(String urnPrefix){
-      return MockMvcRequestBuilders.delete(
-              "/api/v1/models/{urn}",
-              urnPrefix )
-              .with(jwt());
    }
 }

--- a/semantics/semantic-hub/src/test/java/net/catenax/semantics/hub/TestUtils.java
+++ b/semantics/semantic-hub/src/test/java/net/catenax/semantics/hub/TestUtils.java
@@ -20,7 +20,11 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.text.StringEscapeUtils;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 
 public class TestUtils {
 
@@ -44,53 +48,66 @@ public class TestUtils {
       return IOUtils.resourceToString( resourceName, StandardCharsets.UTF_8, TestUtils.class.getClassLoader() );
    }
 
-   public static String createNewModelRequestJson( String model, String status ) {
-      return String.format( "{\n"
-            + "  \"model\": \"%s\",\n"
-            + "  \"status\": \"%s\",\n"
-            + "  \"type\": \"BAMM\"\n"
-            + "}", StringEscapeUtils.escapeJava( model ), status );
-   }
-
-   public static String createValidModelRequest( String urn, String status ) {
+   public static String createValidModelRequest( String urn) {
       String model;
       try {
          model = loadModelFromResources(MODEL_FOR_API_TESTS).replace("{{URN_PREFIX}}", urn);
       } catch (IOException e) {
          throw new RuntimeException("Failed to load file");
       }
-      return String.format( "{\n"
-              + "  \"model\": \"%s\",\n"
-              + "  \"status\": \"%s\",\n"
-              + "  \"type\": \"BAMM\"\n"
-              + "}", StringEscapeUtils.escapeJava( model ), status );
+      return model;
    }
 
-   public static String createDependentModel (String urn, String status) {
+   public static String createDependentModel (String urn) {
       String model;
       try {
          model = loadModelFromResources(DEPENDENT_MODEL).replace("{{URN_PREFIX}}", urn);
       } catch (IOException e) {
          throw new RuntimeException("Failed to load file");
       }
-      return String.format( "{\n"
-              + "  \"model\": \"%s\",\n"
-              + "  \"status\": \"%s\",\n"
-              + "  \"type\": \"BAMM\"\n"
-              + "}", StringEscapeUtils.escapeJava( model ), status );
+      return model;
    }
 
-   public static String createModelDependency (String status) {
+   public static String createModelDependency () {
       String model;
       try {
          model = loadModelFromResources(MODEL_DEPENDENCY);
       } catch (IOException e) {
          throw new RuntimeException("Failed to load file");
       }
-      return String.format( "{\n"
-              + "  \"model\": \"%s\",\n"
-              + "  \"status\": \"%s\",\n"
-              + "  \"type\": \"BAMM\"\n"
-              + "}", StringEscapeUtils.escapeJava( model ), status );
+      return model;
+   }
+
+   public static MockHttpServletRequestBuilder post(String payload) {
+      return post(payload, "DRAFT");
+   }
+
+   public static MockHttpServletRequestBuilder post( String payload, String status ) {
+      String type = "BAMM";
+      return MockMvcRequestBuilders.post( "/api/v1/models")
+              .queryParam("type", type)
+              .queryParam( "status", status)
+              .accept( MediaType.APPLICATION_JSON )
+              .contentType( MediaType.TEXT_PLAIN)
+              .content( payload )
+              .with(jwt());
+   }
+
+   public static MockHttpServletRequestBuilder put( String payload, String status ) {
+      String type = "BAMM";
+      return MockMvcRequestBuilders.put( "/api/v1/models")
+              .queryParam("type", type)
+              .queryParam( "status", status )
+              .accept( MediaType.APPLICATION_JSON )
+              .contentType( MediaType.TEXT_PLAIN )
+              .content( payload )
+              .with(jwt());
+   }
+
+   public static MockHttpServletRequestBuilder delete(String urnPrefix){
+      return MockMvcRequestBuilders.delete(
+                      "/api/v1/models/{urn}",
+                      urnPrefix )
+              .with(jwt());
    }
 }


### PR DESCRIPTION
The /model endpoint for PUT and POST operations now supports text/plain instead of JSON payload. The type and status information are thus encoded as query parameters. This change aims to circumvent encoding issues when inserting Turtle-files as part of JSON payload.