### PR TITLE
Update EDC submodule to special branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/Fraunhofer-AISEC/ids-clearing-house-service
 [submodule "eclipsedataspaceconnector/src"]
 	path = eclipsedataspaceconnector/src
-	url = https://github.com/eclipse-dataspaceconnector/DataSpaceConnector
+	url = https://github.com/drcgjung/DataSpaceConnector.git


### PR DESCRIPTION
The EDC submodule is pointing to a very outdated version.
The Readme.md already mentiones this exact version to build the api-wrapper, but it is not reflected in the submodule.
@drcgjung Can you please check this?
We should only merge this PR if there are no other components depending on the OLD EDC version.
