### PR TITLE
Add edc api wrapper multistage dockerfile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/Fraunhofer-AISEC/ids-clearing-house-service
 [submodule "eclipsedataspaceconnector/src"]
 	path = eclipsedataspaceconnector/src
-	url = https://github.com/eclipse-dataspaceconnector/DataSpaceConnector
+	url = https://github.com/drcgjung/DataSpaceConnector.git

--- a/Dockerfile.build_aas_wrapper
+++ b/Dockerfile.build_aas_wrapper
@@ -5,6 +5,9 @@ RUN apt-get update && apt-get install -y maven
 
 WORKDIR /build
 
+# JAVA build options - 512m is not enough
+ENV _JAVA_OPTIONS="-Xmx2048m"
+
 # build registry, etc
 COPY ./semantics ./semantics
 RUN cd ./semantics && mvn clean install -DskipTests

--- a/Dockerfile.build_aas_wrapper
+++ b/Dockerfile.build_aas_wrapper
@@ -1,0 +1,98 @@
+FROM gradle:jdk11
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+
+RUN apt-get update && apt-get install -y maven
+
+WORKDIR /build
+
+# build registry, etc
+COPY ./semantics ./semantics
+RUN cd ./semantics && mvn clean install -DskipTests
+
+COPY ./eclipsedataspaceconnector ./eclipsedataspaceconnector
+
+# build aasproxy separately (maven based build)
+RUN cd ./eclipsedataspaceconnector/api-wrapper/launchers/aasproxy && mvn clean install -DskipTests
+
+# to cache gradle distribution download
+ENV GRADLE_USER_HOME=/build/.gradle
+RUN cd /build/eclipsedataspaceconnector/src/ && ./gradlew --version
+
+# local cached jar repo
+ENV MAVEN_OPTS="-Dmaven.repo.local=/build/.m2/repository --no-daemon"
+
+# build the EDC and "publish" the jars to the local repo
+RUN cd /build/eclipsedataspaceconnector/src/ && ./gradlew ${MAVEN_OPTS} clean build publishToMavenLocal -x test \
+    && find /build/.m2/repository
+
+# build everything in the api-wrapper
+RUN cd /build/eclipsedataspaceconnector/api-wrapper/ && ./gradlew ${MAVEN_OPTS} clean build
+
+RUN find -name *.jar
+RUN mkdir /jars
+# copy the required jars
+RUN cd /build/eclipsedataspaceconnector/api-wrapper && find -name "*.jar" -exec cp -a --parents {} /jars/ \; && find /jars
+RUN cd /build/semantics && find -name "*.jar" -exec cp -a --parents {} /jars/launchers \; && find /jars
+
+# just show what we have in the build image (this is supposed to be copied over by the individual runtime images)
+RUN find /jars
+
+# create default cert
+# TODO: can we use localhost.localdomain? Do we need an "email" as described in the Readme?
+RUN mkdir /certs
+RUN openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -subj "/CN=localhost.localdomain" -keyout /certs/key.pem -out /certs/cert.pem
+# SECURITY: default password used!
+RUN openssl pkcs12 -inkey /certs/key.pem -in /certs/cert.pem -export -out /certs/cert.pfx -password pass:123456
+
+
+FROM openjdk:11-jre-slim-buster
+ARG JAR
+ARG HTTP_PROXY
+
+ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8090
+ENV SPRING_PROFILES_ACTIVE local,basic
+ENV IDSADAPTER_SERVICEURL http://registry-service:4243
+ENV IDSADAPTER_CONNECTORTYPE edc
+ENV IDSADAPTER_CONNECTORPROTOCOL http
+ENV IDSADAPTER_CONNECTORHOST provider-control-plane:9191
+ENV IDSADAPTER_CONNECTORURL http://provider-control-plane:9191
+ENV IDSADAPTER_CONNECTORUSER X-Api-Key
+ENV IDSADAPTER_CONNECTORPASSWORD 123456
+ENV AASPROXY_REGISTRYURL http://registry-service:4243
+ENV IDSADAPTER_ADAPTERURL http://provider-aas-service:4244
+ENV AASPROXY_WRAPPERURL http://api-wrapper:9191/api/service
+
+RUN if [[ -n "${HTTP_PROXY}"  ]]; then echo "Acquire::http::Proxy \"${HTTP_PROXY}\"" >> /etc/apt/apt.conf.d/proxy.conf; fi && \
+    if [[ -n "${HTTP_PROXY}" ]]; then echo "Acquire::https::Proxy \"${HTTP_PROXY}\"" >> /etc/apt/apt.conf.d/proxy.conf; fi && \
+    apt-get -y upgrade && \
+    apt-get -y update && \
+    apt-get -y install curl && \
+    if [[ -n "${HTTP_PROXY}"  ]]; then rm -f /etc/apt/apt.conf.d/proxy.conf; fi
+
+WORKDIR /app
+
+# copy the relevant jar from the build image
+COPY --from=0 /jars/$JAR app.jar
+RUN ls -la
+
+# copy default cert built in the build image
+RUN mkdir /certs
+COPY --from=0 /certs/* /certs/
+
+EXPOSE 9191
+EXPOSE 8090
+
+ENTRYPOINT java \
+    -Didsadapter.serviceUrl=${IDSADAPTER_SERVICEURL}\
+    -Didsadapter.connectorType=${IDSADAPTER_CONNECTORTYPE}\
+    -Didsadapter.connectorProtocol=${IDSADAPTER_CONNECTORPROTOCOL}\
+    -Didsadapter.connectorHost=${IDSADAPTER_CONNECTORHOST}\
+    -Didsadapter.connectorUrl=${IDSADAPTER_CONNECTORURL}\
+    -Didsadapter.connectorUser=${IDSADAPTER_CONNECTORUSER}\
+    -Didsadapter.connectorPassword=${IDSADAPTER_CONNECTORPASSWORD}\
+    -Didsadapter.adapterUrl=${IDSADAPTER_ADAPTERURL}\
+    -Dspring.profiles.active=${SPRING_PROFILES_ACTIVE}\
+    -Daasproxy.registryUrl=${AASPROXY_REGISTRYURL}\
+    -Daasproxy.wrapperUrl=${AASPROXY_WRAPPERURL}\
+    -Djava.security.edg=file:/dev/.urandom \
+    -jar app.jar

--- a/docker-compose-build_aas_wrapper.yml
+++ b/docker-compose-build_aas_wrapper.yml
@@ -1,0 +1,165 @@
+version: "3.9"
+
+services:
+  consumer-control-plane:
+    build:
+      context: .
+      dockerfile: Dockerfile.build_aas_wrapper
+      args:
+        JAR: launchers/control-plane/build/libs/edc.jar
+        HTTP_PROXY: ${HTTP_PROXY}
+    image: cxtsiacr.azurecr.io/edc/consumer-control-plane:catenax-at-home-latest
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    ports:
+      - "8191:9191" # default
+      - "5005:8090"
+    environment:
+      EDC_VAULT: /config/vault.properties
+      EDC_KEYSTORE: /certs/cert.pfx
+      EDC_KEYSTORE_PASSWORD: 123456
+      EDC_FS_CONFIG: /config/configuration.properties
+    volumes:
+      - ${PWD}/eclipsedataspaceconnector/api-wrapper/config/consumer-control-plane.config:/config
+
+  consumer-data-plane:
+    build:
+      context: .
+      dockerfile: Dockerfile.build_aas_wrapper
+      args:
+        JAR: launchers/data-plane/build/libs/edc.jar
+        HTTP_PROXY: ${HTTP_PROXY}
+    image: cxtsiacr.azurecr.io/edc/consumer-data-plane:catenax-at-home-latest
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    ports:
+      - "8192:9191" # default
+      - "5006:8090"
+    environment:
+      EDC_FS_CONFIG: /config/configuration.properties
+    volumes:
+     - ${PWD}/eclipsedataspaceconnector/api-wrapper/config/consumer-data-plane.config:/config
+
+  api-wrapper:
+    build:
+      context: .
+      dockerfile: Dockerfile.build_aas_wrapper
+      args:
+        JAR: launchers/api-wrapper/build/libs/edc.jar
+        HTTP_PROXY: ${HTTP_PROXY}
+    image: cxtsiacr.azurecr.io/edc/consumer-api-wrapper:catenax-at-home-latest
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    ports:
+      - "8193:9191" # default
+#      - "9192" # callback
+      - "5007:8090"
+    environment:
+      EDC_FS_CONFIG: /config/configuration.properties
+    volumes:
+      - ${PWD}/eclipsedataspaceconnector/api-wrapper/config/api-wrapper.config:/config
+
+  provider-control-plane:
+    build:
+      context: .
+      dockerfile: Dockerfile.build_aas_wrapper
+      args:
+        JAR: launchers/control-plane/build/libs/edc.jar
+        HTTP_PROXY: ${HTTP_PROXY}
+    image: cxtsiacr.azurecr.io/edc/provider-control-plane:catenax-at-home-latest
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    ports:
+      - "8181:9191" # default
+      - "8184:9192" # validation
+      - "5008:8090"
+    environment:
+      EDC_VAULT: /config/vault.properties
+      EDC_KEYSTORE: /certs/cert.pfx
+      EDC_KEYSTORE_PASSWORD: 123456
+      EDC_FS_CONFIG: /config/configuration.properties
+    volumes:
+      - ${PWD}/eclipsedataspaceconnector/api-wrapper/config/provider-control-plane.config:/config
+
+  provider-data-plane:
+    build:
+      context: .
+      dockerfile: Dockerfile.build_aas_wrapper
+      args:
+        JAR: launchers/data-plane/build/libs/edc.jar
+        HTTP_PROXY: ${HTTP_PROXY}
+    image: cxtsiacr.azurecr.io/edc/provider-data-plane:catenax-at-home-latest
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    ports:
+      - "8182:9191" # default
+      - "8183:9192" # public
+      - "5009:8090"
+    environment:
+      EDC_FS_CONFIG: /config/configuration.properties
+    volumes:
+      - ${PWD}/eclipsedataspaceconnector/api-wrapper/config/provider-data-plane.config:/config
+
+  provider-backend-service:
+    build:
+      context: .
+      dockerfile: Dockerfile.build_aas_wrapper
+      args:
+        JAR: launchers/provider-backend-service/build/libs/edc.jar
+        HTTP_PROXY: ${HTTP_PROXY}
+    image: cxtsiacr.azurecr.io/edc/provider-api-wrapper:catenax-at-home-latest
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    ports:
+      - "8194:9191" # default
+      - "5010:8090"
+    environment:
+      EDC_FS_CONFIG: /config/configuration.properties
+    volumes:
+      - ${PWD}/eclipsedataspaceconnector/api-wrapper/config/provider-backend-service.config:/config
+
+  provider-aas-service:
+    build:
+      context: .
+      dockerfile: Dockerfile.build_aas_wrapper
+      args:
+        JAR: launchers/adapter/target/adapter-1.3.0-SNAPSHOT.jar
+        HTTP_PROXY: ${HTTP_PROXY}
+    image: cxtsiacr.azurecr.io/backend/simple-aas-adapter:catenax-at-home-latest
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    ports:
+      - "4244:4244" # default
+      - "5011:8090"
+
+  hub-service:
+    build:
+      context: .
+      dockerfile: Dockerfile.build_aas_wrapper
+      args:
+        JAR: launchers/semantic-hub/target/semantic-hub-1.3.0-SNAPSHOT.jar
+        HTTP_PROXY: ${HTTP_PROXY}
+    image: cxtsiacr.azurecr.io/semantics/hub:catenax-at-home-latest
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    ports:
+      - "4242:4242" # default
+      - "5012:8090"
+
+  registry-service:
+    build:
+      context: .
+      dockerfile: Dockerfile.build_aas_wrapper
+      args:
+        JAR: launchers/registry/target/registry-1.3.0-SNAPSHOT.jar
+        HTTP_PROXY: ${HTTP_PROXY}
+    image: cxtsiacr.azurecr.io/semantics/registry:catenax-at-home-latest
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    ports:
+      - "4243:4243" # default
+      - "5013:8090"
+
+  consumer-aas-proxy-service:
+    build:
+      context: .
+      dockerfile: Dockerfile.build_aas_wrapper
+      args:
+        JAR: launchers/aasproxy/target/aasproxy-1.0.0-SNAPSHOT.jar
+        HTTP_PROXY: ${HTTP_PROXY}
+    image: cxtsiacr.azurecr.io/edc/consumer-aas-proxy:catenax-at-home-latest
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    ports:
+      - "4245:4245" # default
+      - "5014:8090"


### PR DESCRIPTION
Adds a multistage build file for the docker-compose setup for all the components around "api-wrapper".
Since content from ./semantics is used, the files had to be moved to the root directory.
Also the default certs have been updated. There is no certs in the mounted config directories. Therefore, a default cert is created during build.

@drcgjung Can you please review this change?
