### PR TITLE
registry: Adding registry profile to be able to build independently

### DIFF
--- a/semantics/pom.xml
+++ b/semantics/pom.xml
@@ -110,12 +110,7 @@
 	</properties>
 
 	<modules>
-		<module>framework</module>
-		<module>framework/dsc</module>
-		<module>framework/edc</module>
-		<module>adapter</module>
-		<module>semantic-hub</module>
-		<module>registry</module>
+        <!-- check profiles below -->
     </modules>
 
 	<dependencyManagement>
@@ -513,6 +508,26 @@
 				</snapshotRepository>
 			</distributionManagement>
 		</profile>
+        <profile>
+            <id>default</id>
+            <activation>
+            <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>framework</module>
+                <module>framework/dsc</module>
+                <module>framework/edc</module>
+                <module>adapter</module>
+                <module>semantic-hub</module>
+                <module>registry</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>registry</id>
+            <modules>
+                <module>registry</module>
+            </modules>
+        </profile>
 	</profiles>
 
 </project>


### PR DESCRIPTION
"-P registry" allows to build the registry without the other semantics
modules

If not profile is given, the "default" profile is built, which
contains all other modules (behavior as before the change)

@fmisir Can you please review?
Matthias
